### PR TITLE
Bugfix: Limit nvidia-device-plugin to gpu instance types

### DIFF
--- a/helm_chart/HyperPodHelmChart/values.yaml
+++ b/helm_chart/HyperPodHelmChart/values.yaml
@@ -138,11 +138,57 @@ nvidia-device-plugin:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms: 
         - matchExpressions:
-          # nvidia plugin needs at least one node selector. Below label exists for all hyperpod nodes
-          - key: kubernetes.io/os
+          - key: node.kubernetes.io/instance-type
             operator: In
             values:
-            - "linux"
+            - ml.g4dn.12xlarge
+            - ml.g4dn.16xlarge
+            - ml.g4dn.2xlarge
+            - ml.g4dn.4xlarge
+            - ml.g4dn.8xlarge
+            - ml.g4dn.metal
+            - ml.g4dn.xlarge
+            - ml.g5.12xlarge
+            - ml.g5.16xlarge
+            - ml.g5.24xlarge
+            - ml.g5.2xlarge
+            - ml.g5.48xlarge
+            - ml.g5.4xlarge
+            - ml.g5.8xlarge
+            - ml.g5.xlarge
+            - ml.g5g.16xlarge
+            - ml.g5g.2xlarge
+            - ml.g5g.4xlarge
+            - ml.g5g.8xlarge
+            - ml.g5g.metal
+            - ml.g5g.xlarge
+            - ml.g6.12xlarge
+            - ml.g6.16xlarge
+            - ml.g6.24xlarge
+            - ml.g6.2xlarge
+            - ml.g6.48xlarge
+            - ml.g6.4xlarge
+            - ml.g6.8xlarge
+            - ml.g6.xlarge
+            - ml.g6e.12xlarge
+            - ml.g6e.16xlarge
+            - ml.g6e.24xlarge
+            - ml.g6e.2xlarge
+            - ml.g6e.48xlarge
+            - ml.g6e.4xlarge
+            - ml.g6e.8xlarge
+            - ml.g6e.xlarge
+            - ml.gr6.4xlarge
+            - ml.gr6.8xlarge
+            - ml.p2.16xlarge
+            - ml.p2.8xlarge
+            - ml.p2.xlarge
+            - ml.p3.16xlarge
+            - ml.p3.2xlarge
+            - ml.p3.8xlarge
+            - ml.p3dn.24xlarge
+            - ml.p4d.24xlarge
+            - ml.p5.48xlarge
   tolerations:
     - key: nvidia.com/gpu
       operator: Exists


### PR DESCRIPTION
### Motivation

Nvidia device plugin (running as a DaemonSet) is currently set to run on all instances running `linux` os. Pods created by this DaemonSet in instances that don't have an Nvidia GPU perpetually stay in `CrashLoopBackOff` state due to init error (_no gpu device detected_). This change is for limiting pods to instances that we know for certain have an Nvidia GPU to launch only stable pods. 

---

Instance types that use Nvidia GPUs were pulled directly from EC2 using a simple script pasted below,
```
import boto3
ec2 = boto3.client('ec2', region_name='us-east-1')
instance_types = ec2.get_paginator('describe_instance_types').paginate().build_full_result()['InstanceTypes']

gpu_instances = []
for instance in instance_types:
	if not 'GpuInfo' in instance: continue
	gpus = instance['GpuInfo'].get('Gpus', [])
	nvidia_gpus = [gpu for gpu in gpus if gpu['Manufacturer'] == 'NVIDIA']
	if nvidia_gpus:
		gpu_instances.append(instance['InstanceType'])

gpu_instances.sort()
for i in gpu_instances: print("- ml." + i) # Printing as yaml array for convenience
```

This may contain instance types that are not supported by Hyperpod today, it's better to keep them in the interest of future proofing.



## Testing

Created a hyperpod cluster with 3 instance groups (2 cpu, 1 gpu) and deployed updated helm chart. 
Verified NVD DaemonSet pods were only launched in gpu nodes.

```
# g5.2xlarge has GPUs, others don't. 
bash-3.2$ kubectl get nodes -o=custom-columns=NAME:.metadata.name,LABEL:.metadata.labels.'node\.kubernetes\.io/instance-type'
NAME                                         LABEL
hyperpod-i-030ad565a57fcced8                 ml.c5.2xlarge
hyperpod-i-05b04af8627a2e65c                 ml.g5.2xlarge
hyperpod-i-0d173f3bbea28b862                 ml.m5.xlarge
ip-10-2-249-242.us-west-2.compute.internal   c5.xlarge
ip-10-3-212-25.us-west-2.compute.internal    c5.xlarge

# Just one nvidia device plugin pod is running
bash-3.2$ kubectl get pods -A | grep nvidia
kube-system    hyperpod-dependencies-nvidia-device-plugin-ps7w4             1/1     Running   0          6m56s

# And that pod is running in g5.2xlarge instance
bash-3.2$ kubectl describe pod hyperpod-dependencies-nvidia-device-plugin-ps7w4 -n kube-system | grep -i node
Priority Class Name:  system-node-critical
Node:                 hyperpod-i-05b04af8627a2e65c/10.2.12.34
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/disk-pressure:NoSchedule op=Exists
                             node.kubernetes.io/memory-pressure:NoSchedule op=Exists
                             node.kubernetes.io/not-ready:NoExecute op=Exists
                             node.kubernetes.io/pid-pressure:NoSchedule op=Exists
                             node.kubernetes.io/unreachable:NoExecute op=Exists
                             node.kubernetes.io/unschedulable:NoSchedule op=Exists
                             sagemaker.amazonaws.com/node-health-status=Unschedulable:NoSchedule
```


