### PR TITLE
pin sagemaker-hyperpod-recipes to 1.3.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/hyperpod_cli/sagemaker_hyperpod_recipes"]
 	path = src/hyperpod_cli/sagemaker_hyperpod_recipes
 	url = https://github.com/aws/sagemaker-hyperpod-recipes.git
-	branch = main
+	branch = 1.3.1


### PR DESCRIPTION
# Description
1.3.2 release of sagemaker-hyperpod-recipes introduced a bug to `hyperpod start-job`. See error log below, pinning the version of recipes repo will stabilize this cli.
```
2025-03-05 00:19:16 - hyperpod_cli.commands.job - ERROR - Command failed with exit code 1
2025-03-05 00:19:16 - hyperpod_cli.commands.job - ERROR - Error executing job with overrides: ['base_results_dir=/home/sagemaker-user/DemoNotebooks/results', 'cluster.cluster_type=k8s']
Traceback (most recent call last):
  File "/opt/conda/lib/python3.11/site-packages/hyperpod_cli/sagemaker_hyperpod_recipes/main.py", line 270, in <module>
    main()
  File "/opt/conda/lib/python3.11/site-packages/hydra/main.py", line 94, in decorated_main
    _run_hydra(
  File "/opt/conda/lib/python3.11/site-packages/hydra/_internal/utils.py", line 394, in _run_hydra
    _run_app(
  File "/opt/conda/lib/python3.11/site-packages/hydra/_internal/utils.py", line 457, in _run_app
    run_and_report(
  File "/opt/conda/lib/python3.11/site-packages/hydra/_internal/utils.py", line 223, in run_and_report
    raise ex
  File "/opt/conda/lib/python3.11/site-packages/hydra/_internal/utils.py", line 220, in run_and_report
    return func()
           ^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/hydra/_internal/utils.py", line 458, in <lambda>
    lambda: hydra.run(
            ^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/hydra/_internal/hydra.py", line 132, in run
    _ = ret.return_value
        ^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/hydra/core/utils.py", line 260, in return_value
    raise self._return_value
  File "/opt/conda/lib/python3.11/site-packages/hydra/core/utils.py", line 186, in run_job
    ret.return_value = task_function(task_cfg)
                       ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/hyperpod_cli/sagemaker_hyperpod_recipes/validations_wrapper.py", line 36, in validations_wrapper
    return fn(config, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/hyperpod_cli/sagemaker_hyperpod_recipes/main.py", line 230, in main
    has_custom_script, has_sm_recipe = preprocess_config(cfg)
                                       ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/hyperpod_cli/sagemaker_hyperpod_recipes/main.py", line 161, in preprocess_config
    cfg.recipes.run.name = valid_run_name(cfg)
                           ^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/hyperpod_cli/sagemaker_hyperpod_recipes/main.py", line 140, in valid_run_name
    if cfg.recipes.get("run") is None:
       ^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/omegaconf/dictconfig.py", line 359, in __getattr__
    self._format_and_raise(key=key, value=None, cause=e)
  File "/opt/conda/lib/python3.11/site-packages/omegaconf/base.py", line 231, in _format_and_raise
    format_and_raise(
  File "/opt/conda/lib/python3.11/site-packages/omegaconf/_utils.py", line 819, in format_and_raise
    _raise(ex, cause)
  File "/opt/conda/lib/python3.11/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/omegaconf/dictconfig.py", line 351, in __getattr__
    return self._get_impl(
           ^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/omegaconf/dictconfig.py", line 442, in _get_impl
    node = self._get_child(
           ^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/omegaconf/basecontainer.py", line 73, in _get_child
    child = self._get_node(
            ^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/omegaconf/dictconfig.py", line 475, in _get_node
    self._validate_get(key)
  File "/opt/conda/lib/python3.11/site-packages/omegaconf/dictconfig.py", line 164, in _validate_get
    self._format_and_raise(
  File "/opt/conda/lib/python3.11/site-packages/omegaconf/base.py", line 231, in _format_and_raise
    format_and_raise(
  File "/opt/conda/lib/python3.11/site-packages/omegaconf/_utils.py", line 899, in format_and_raise
    _raise(ex, cause)
  File "/opt/conda/lib/python3.11/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
omegaconf.errors.ConfigAttributeError: Key 'recipes' is not in struct
    full_key: recipes
    object_type=dict
```
# PR Approval Steps

## For Requester

1. Description
    - [x] Check the PR title and description for clarity. It should describe the changes made and the reason behind them.
    - [x] Ensure that the PR follows the contribution guidelines, if applicable.
2. Security requirements
    - [x] Ensure that a Pull Request (PR) does not expose passwords and other sensitive information by using git-secrets and upload relevant evidence: https://github.com/awslabs/git-secrets
    - [x] Ensure commit has GitHub Commit Signature
3. Manual review
    1. Click on the Files changed tab to see the code changes. Review the changes thoroughly:
        - [x] Code Quality: Check for coding standards, naming conventions, and readability.
        - [x] Functionality: Ensure that the changes meet the requirements and that all necessary code paths are tested.
        - [x] Security: Check for any security issues or vulnerabilities.
        - [x] Documentation: Confirm that any necessary documentation (code comments, README updates, etc.) has been updated.
4. Check for Merge Conflicts:
    - [x] Verify if there are any merge conflicts with the base branch. GitHub will usually highlight this. If there are conflicts, you should resolve them.
      
## For Reviewer

1. Go through `For Requester` section to double check each item.
2. Request Changes or Approve the PR:
    1. If the PR is ready to be merged, click Review changes and select Approve.
    2. If changes are required, select Request changes and provide feedback. Be constructive and clear in your feedback.
3. Merging the PR
    1. Check the Merge Method:
        1. Decide on the appropriate merge method based on your repository's guidelines (e.g., Squash and merge, Rebase and merge, or Merge).
    2. Merge the PR:
        1. Click the Merge pull request button.
        2. Confirm the merge by clicking Confirm merge.

