### PR TITLE
revert node-count val

### DIFF
--- a/hyperpod-pytorch-job-template/hyperpod_pytorch_job_template/v1_1/model.py
+++ b/hyperpod-pytorch-job-template/hyperpod_pytorch_job_template/v1_1/model.py
@@ -110,7 +110,7 @@ class PyTorchJobConfig(BaseModel):
         min_length=1
     )
     node_count: Optional[int] = Field(
-        default=1,
+        default=None,
         alias="node_count", 
         description="Number of nodes",
         ge=1

--- a/hyperpod-pytorch-job-template/hyperpod_pytorch_job_template/v1_1/schema.json
+++ b/hyperpod-pytorch-job-template/hyperpod_pytorch_job_template/v1_1/schema.json
@@ -202,7 +202,7 @@
           "type": "null"
         }
       ],
-      "default": 1,
+      "default": null,
       "description": "Number of nodes",
       "title": "Node Count"
     },


### PR DESCRIPTION
## What's changing and why?
<!-- Describe what you're changing and the motivation behind it -->

the pytorch job expects 1 of the following 2 (not both)
1. `node-count`
2. `combination of accelerators, vcpu, memory-in-gib must be specified for instance-type ml.p4d.24xlarge`

this change reverts the default of node_count back to None, so users can specify on the pytorch job flags whether they want one or the other.


## How was this change tested?
<!-- Describe your testing approach -->
tested locally by running commands like
```
hyp create hyp-pytorch-job \
  --version 1.1 \
  --job-name my-training-job \
  --image pytorch/pytorch:latest \
  --command '[python, train.py]' \ 
  --instance-type ml.g5.8xlarge \
  --tasks-per-node 1 \
  --accelerators 1 \
  --accelerators-limit 1 \
  --vcpu 8 \
  --vcpu-limit 8 \
  --memory 32 \
  --memory-limit 32
```



## Unit test coverage
<!-- Check unit test coverage for your changes -->
- [ ] All new/modified code has unit tests
- [ ] Coverage verified for changed code
- [ ] N/A - no testable code changes

## Do we need integration tests?
<!-- Consider if integration tests are needed -->
- [ ] Yes - integration tests added
- [ ] No - unit tests sufficient
- [ ] No - infrastructure/config change only
- [ ] Unsure - please advise

---

## Checklist
- [ ] PR title clearly describes the change
- [ ] No sensitive information exposed and security is maintained
- [ ] Ready for review