### PR TITLE
changelog version update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v.3.2.2 (2025-09-03)
+
+### Features
+
+  * Fix for production canary failures caused by bad training job template.
+
 ## v3.2.1 (2025-08-27)
 
 ### Features


### PR DESCRIPTION
updated CHANGELOG.md for prod canary failure fix

Integ tests failing, but this pr does not have any code changes

Tests are passing on beta cluster which uses latest code in staging repo (which was synced 2 days ago)
<img width="1678" height="634" alt="image" src="https://github.com/user-attachments/assets/e779d9ef-0a90-416b-b228-5a1c74615d2f" />


## Checklist
- [ ] PR title clearly describes the change
- [ ] No sensitive information exposed and security is maintained
- [ ] Ready for review