### PR TITLE
Code Coverage for Integ Tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -59,8 +59,8 @@ addopts =
     --durations=5
     # Default to colorful output
     --color=yes
-    # Uncomment to enforce a minimum code coverage threshold.
-    # --cov-fail-under 50
+    # Enforce a minimum code coverage threshold
+    --cov-fail-under 50
 testpaths = test
 looponfailroots = src test
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,11 +21,8 @@ commands =
 
 [testenv:integ]
 description = Run integration tests
-deps = 
-    pytest-cov
-    -e .
 commands =
-    pytest test/integration_tests --cov=sagemaker.hyperpod --cov-report=term-missing --cov-report=xml:coverage.xml
+    pytest test/integration_tests
 
 [testenv:coverage]
 description = Run unit tests with coverage


### PR DESCRIPTION
## What's changing and why?
<!-- Describe what you're changing and the motivation behind it -->
Adding code coverage for integration tests to give more visibility into how much of the codebase integration tests currently support and also providing the team feedback on when adding additional integration tests may be necessary.

## Before/After UX
<!-- Show the user experience before and after your changes -->
**Before:**
No code coverage visible for integration tests.

**After:**
A report at the end of the integration test check will generate with code coverage metrics.

## How was this change tested?
<!-- Describe your testing approach -->
Code coverage was checked in the GitHub workflow for integration tests.

## Are unit tests added?
No unit tests needed.

## Are integration tests added?
No integ tests needed.

## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [ ] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only