### PR TITLE
Fix Slurm failures from missing orchestration key

### DIFF
--- a/src/sagemaker/hyperpod/cli/commands/cluster.py
+++ b/src/sagemaker/hyperpod/cli/commands/cluster.py
@@ -584,6 +584,11 @@ def set_cluster_context(
         sm_client = get_sagemaker_client(session, botocore_config)
         hp_cluster_details = sm_client.describe_cluster(ClusterName=cluster_name)
         logger.debug("Fetched hyperpod cluster details")
+        
+        # Check if cluster is EKS-orchestrated
+        if "Orchestrator" not in hp_cluster_details or "Eks" not in hp_cluster_details.get("Orchestrator", {}):
+            raise ValueError(f"Cluster '{cluster_name}' is not EKS-orchestrated. HyperPod CLI only supports EKS-orchestrated clusters.")
+        
         store_current_hyperpod_context(hp_cluster_details)
         eks_cluster_arn = hp_cluster_details["Orchestrator"]["Eks"]["ClusterArn"]
         logger.debug(

--- a/test/unit_tests/common/test_utils.py
+++ b/test/unit_tests/common/test_utils.py
@@ -389,7 +389,12 @@ class TestUtilityFunctions(unittest.TestCase):
         
         set_cluster_context("my-cluster", "us-west-2", "test-namespace")
         
-        mock_client.describe_cluster.assert_called_once_with(ClusterName="my-cluster")
+        # Expect 2 calls: one for is_eks_orchestrator validation, one for getting cluster details
+        self.assertEqual(mock_client.describe_cluster.call_count, 2)
+        mock_client.describe_cluster.assert_has_calls([
+            call(ClusterName="my-cluster"),
+            call(ClusterName="my-cluster")
+        ])
         mock_get_name.assert_called_once()
         mock_update_config.assert_called_once()
         mock_set_context_func.assert_called_once()


### PR DESCRIPTION
## What's changing and why?
<!-- Describe what you're changing and the motivation behind it -->
This is a bug fix relating to the following GitHub issue: https://github.com/aws/sagemaker-hyperpod-cli/issues/264
Essentially, the "Orchestrator" key is only available for EKS clusters and not Slurm clusters. This leads to KeyErrors whenever a user has a running Slurm Cluster but calls commands like hyp create (which calls list_clusters() in the backend and was failing previously) or hyp set-cluster-context (which calls set_cluster_context() in the background, which gives an odd KeyError if trying to set your cluster context to a slurm cluster). 

## Before/After UX
<!-- Show the user experience before and after your changes -->
**Before:**
Customers could not use certain HP CLI commands (such as create() or set_cluster_context()) effectively if they had at least one running Slurm cluster in their account.

**After:**
Customers can use HP CLI normally while simultaneously having running Slurm clusters in their account.


## How was this change tested?
<!-- Describe your testing approach -->
Verified that fixes enable endpoint deployment for customers with Slurm cluster in their account. Waiting for unit/integ tests to run in GItHub workflow

## Are unit tests added?
Not needed

## Are integration tests added?
We may want to add a placeholder Slurm cluster in our beta/prod account to ensure that this isn't an issue for the future. This does not require any changes to existing tests, but adding this could help us prevent issues like this in the future.

## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [ ] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only