### PR TITLE
Add ml.p5.4xlarge instance type support

### DIFF
--- a/src/sagemaker/hyperpod/training/quota_allocation_util.py
+++ b/src/sagemaker/hyperpod/training/quota_allocation_util.py
@@ -25,6 +25,7 @@ INSTANCE_RESOURCES = {
     "ml.p4d.24xlarge": {"cpu": 96, "gpu": 8, "trainium": 0, "memory": 1152},
     "ml.p4de.24xlarge": {"cpu": 96, "gpu": 8, "trainium": 0, "memory": 1152},
     "ml.p5.48xlarge": {"cpu": 192, "gpu": 8, "trainium": 0, "memory": 2048},
+    "ml.p5.4xlarge": {"cpu": 16, "gpu": 1, "trainium": 0, "memory": 256},
     "ml.trn1.32xlarge": {"cpu": 128, "gpu": 0, "trainium": 16, "memory": 512},
     "ml.trn1n.32xlarge": {"cpu": 128, "gpu": 0, "trainium": 16, "memory": 512},
     "ml.g5.xlarge": {"cpu": 4, "gpu": 1, "trainium": 0, "memory": 16},


### PR DESCRIPTION
## What's changing and why?
Added ml.p5.4xlarge instance type to INSTANCE_RESOURCES dictionary to enable proper resource quota allocation for this instance type. source: https://aws.amazon.com/ec2/instance-types/p5/


## Before/After UX
<!-- Show the user experience before and after your changes -->
**Before:**
Operations using ml.p5.4xlarge would fail due to missing resource definitions.

**After:**
Users can use ml.p5.4xlarge instance type with proper resource quota validation.

## How was this change tested?
No - data-only change to hardcoded dictionary.

## Are unit tests added?
No - data-only change to hardcoded dictionary.

## Are integration tests added?
No - data-only change to hardcoded dictionary.

## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [ ] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only