### PR TITLE
Add Deep Health Check and HMA support for p5.4xlarge instance type

### DIFF
--- a/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/templates/health-monitoring-agent.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/templates/health-monitoring-agent.yaml
@@ -75,6 +75,7 @@ spec:
                       - ml.p5en.48xlarge
                       - ml.p5e.48xlarge
                       - ml.p5.48xlarge
+                      - ml.p5.4xlarge
                       - ml.p4d.24xlarge
                       - ml.p4de.24xlarge
                       - ml.g5.xlarge

--- a/helm_chart/HyperPodHelmChart/values.yaml
+++ b/helm_chart/HyperPodHelmChart/values.yaml
@@ -186,6 +186,7 @@ nvidia-device-plugin:
               - ml.gr6.8xlarge
               - ml.p4d.24xlarge
               - ml.p4de.24xlarge
+              - ml.p5.4xlarge
               - ml.p5.48xlarge
               - ml.p5e.48xlarge
               - ml.p5en.48xlarge
@@ -246,6 +247,7 @@ aws-efa-k8s-device-plugin:
       - ml.m7i.48xlarge
       - ml.p4d.24xlarge
       - ml.p4de.24xlarge
+      - ml.p5.4xlarge
       - ml.p5.48xlarge
       - ml.p5e.48xlarge
       - ml.p5en.48xlarge


### PR DESCRIPTION
## What's changing and why?
Adding Deep Health Check and HMA support for ml.p5.4xlarge instances. 


## Before/After UX
<!-- Show the user experience before and after your changes -->
**Before:**
Deep Health Check and HMA not supported for ml.p5.4xlarge instances.

**After:**
Deep Health Check and HMA is supported for ml.p5.4xlarge instances.

## How was this change tested?
This change was tested for ml.p5.4xlarge instances for Deep Health Check and HMA.

## Are unit tests added?
No - only changes to config.

## Are integration tests added?
No - only changes to config.

## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [ ] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only