### PR TITLE
Update inference operator version in HyperPodHelmChart to match new release

### DIFF
--- a/helm_chart/HyperPodHelmChart/Chart.yaml
+++ b/helm_chart/HyperPodHelmChart/Chart.yaml
@@ -81,7 +81,7 @@ dependencies:
     repository: "file://charts/team-role-and-bindings"
     condition: team-role-and-bindings.enabled
   - name: hyperpod-inference-operator
-    version: "0.1.0"
+    version: "1.0.0"
     repository: "file://charts/inference-operator"
     condition: inferenceOperators.enabled 
   - name: hyperpod-patching


### PR DESCRIPTION


## What's changing and why?

As title says, update version in parent chart to match new helm version of HyperPod Inference Operator chart.

## How was this change tested?

`helm dependency update .`


## Are unit tests added?

No.

## Are integration tests added?

No.

## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [ ] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only