### PR TITLE
Add regional values for ap-northeast-2 and ca-central-1 for GPU operator

### DIFF
--- a/helm_chart/HyperPodHelmChart/charts/gpu-operator/regional-values/values-ap-northeast-2.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/gpu-operator/regional-values/values-ap-northeast-2.yaml
@@ -1,0 +1,15 @@
+gpu-operator:
+  operator:
+    repository: "743267407464.dkr.ecr.ap-northeast-2.amazonaws.com"
+  toolkit:
+    repository: "743267407464.dkr.ecr.ap-northeast-2.amazonaws.com/mirror-k8s"
+  devicePlugin:
+    repository: "743267407464.dkr.ecr.ap-northeast-2.amazonaws.com"
+  gfd:
+    repository: "743267407464.dkr.ecr.ap-northeast-2.amazonaws.com"
+  migManager:
+    repository: "743267407464.dkr.ecr.ap-northeast-2.amazonaws.com/mirror-cloud-native"
+  validator:
+    repository: "743267407464.dkr.ecr.ap-northeast-2.amazonaws.com/mirror-cloud-native"
+
+

--- a/helm_chart/HyperPodHelmChart/charts/gpu-operator/regional-values/values-ca-central-1.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/gpu-operator/regional-values/values-ca-central-1.yaml
@@ -1,0 +1,13 @@
+gpu-operator:
+  operator:
+    repository: "035462350821.dkr.ecr.ca-central-1.amazonaws.com"
+  toolkit:
+    repository: "035462350821.dkr.ecr.ca-central-1.amazonaws.com/mirror-k8s"
+  devicePlugin:
+    repository: "035462350821.dkr.ecr.ca-central-1.amazonaws.com"
+  gfd:
+    repository: "035462350821.dkr.ecr.ca-central-1.amazonaws.com"
+  migManager:
+    repository: "035462350821.dkr.ecr.ca-central-1.amazonaws.com/mirror-cloud-native"
+  validator:
+    repository: "035462350821.dkr.ecr.ca-central-1.amazonaws.com/mirror-cloud-native"

--- a/helm_chart/HyperPodHelmChart/regional-values/values-ap-northeast-2.yaml
+++ b/helm_chart/HyperPodHelmChart/regional-values/values-ap-northeast-2.yaml
@@ -1,0 +1,16 @@
+gpu-operator:
+  gpu-operator:
+    operator:
+      repository: "743267407464.dkr.ecr.ap-northeast-2.amazonaws.com"
+    toolkit:
+      repository: "743267407464.dkr.ecr.ap-northeast-2.amazonaws.com/mirror-k8s"
+    devicePlugin:
+      repository: "743267407464.dkr.ecr.ap-northeast-2.amazonaws.com"
+    gfd:
+      repository: "743267407464.dkr.ecr.ap-northeast-2.amazonaws.com"
+    migManager:
+      repository: "743267407464.dkr.ecr.ap-northeast-2.amazonaws.com/mirror-cloud-native"
+    validator:
+      repository: "743267407464.dkr.ecr.ap-northeast-2.amazonaws.com/mirror-cloud-native"
+
+

--- a/helm_chart/HyperPodHelmChart/regional-values/values-ca-central-1.yaml
+++ b/helm_chart/HyperPodHelmChart/regional-values/values-ca-central-1.yaml
@@ -1,0 +1,16 @@
+gpu-operator:
+  gpu-operator:
+    operator:
+      repository: "035462350821.dkr.ecr.ca-central-1.amazonaws.com"
+    toolkit:
+      repository: "035462350821.dkr.ecr.ca-central-1.amazonaws.com/mirror-k8s"
+    devicePlugin:
+      repository: "035462350821.dkr.ecr.ca-central-1.amazonaws.com"
+    gfd:
+      repository: "035462350821.dkr.ecr.ca-central-1.amazonaws.com"
+    migManager:
+      repository: "035462350821.dkr.ecr.ca-central-1.amazonaws.com/mirror-cloud-native"
+    validator:
+      repository: "035462350821.dkr.ecr.ca-central-1.amazonaws.com/mirror-cloud-native"
+
+


### PR DESCRIPTION
## What's changing and why?
<!-- Describe what you're changing and the motivation behind it -->
Adding support for (2) additional regions for the GPU operator Helm chart.


## Before/After UX
<!-- Show the user experience before and after your changes -->
**Before:**
Before: No support for ICN and YUL.

**After:**
Adding support for (2) additional regions for the GPU operator Helm chart.

## How was this change tested?
<!-- Describe your testing approach -->
```
helm upgrade dependencies helm_chart/HyperPodHelmChart \
--set gpu-operator.enabled=true \
--set nvidia-device-plugin.devicePlugin.enabled=false \
-f helm_chart/HyperPodHelmChart/ecr-values/values-{$AWS_REGION}.yaml \
-n kube-system
```
```
helm list -A
```
```
kubectl get pods -n kube-system
```
```
kubectl describe pod $GPU_OPERATOR_COMPONENT_POD -n kube-system
```
```
kubectl describe node -n kube-system
```

## Are unit tests added?
No

## Are integration tests added?
No

## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [ ] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only