### PR TITLE
Bug fixes for cluster creation and pytorch job

### DIFF
--- a/hyperpod-pytorch-job-template/hyperpod_pytorch_job_template/v1_1/template.py
+++ b/hyperpod-pytorch-job-template/hyperpod_pytorch_job_template/v1_1/template.py
@@ -84,7 +84,7 @@ spec:
 {%-             endfor %}
 {%-           endif %}
               resources:
-{%-           if accelerators or vcpu or memory %}
+{%-           if accelerators or vcpu or memory or (node_count and node_count > 1) %}
                 requests:
 {%-             if accelerators %}
                   nvidia.com/gpu: {{ accelerators }}
@@ -95,11 +95,14 @@ spec:
 {%-             if memory %}
                   memory: {{ memory }}Gi
 {%-             endif %}
+{%-             if (node_count and node_count > 1) %}
+                  vpc.amazonaws.com/efa: 1
+{%-             endif %}
 {%-           else %}
                 requests:
                   nvidia.com/gpu: "0"
 {%-           endif %}
-{%-           if accelerators_limit or vcpu_limit or memory_limit %}
+{%-           if accelerators_limit or vcpu_limit or memory_limit or (node_count and node_count > 1) %}
                 limits:
 {%-             if accelerators_limit %}
                   nvidia.com/gpu: {{ accelerators_limit }}
@@ -109,6 +112,9 @@ spec:
 {%-             endif %}
 {%-             if memory_limit %}
                   memory: {{ memory_limit }}Gi
+{%-             endif %}
+{%-             if (node_count and node_count > 1) %}
+                  vpc.amazonaws.com/efa: 1
 {%-             endif %}
 {%-           else %}
                 limits:

--- a/src/sagemaker/hyperpod/cli/commands/cluster_stack.py
+++ b/src/sagemaker/hyperpod/cli/commands/cluster_stack.py
@@ -30,6 +30,19 @@ from sagemaker.hyperpod.cli.cluster_stack_utils import (
 logger = logging.getLogger(__name__)
 
 
+def get_newest_template_version() -> int:
+    """Get the newest available template version.
+    
+    Returns:
+        int: The newest template version number
+        
+    TODO: Implement logic to fetch the actual newest template version
+    from the template registry or remote source.
+    """
+    # Placeholder implementation - currently returns 1 as the latest version
+    return 1
+
+
 def parse_status_list(ctx, param, value):
     """Parse status list from string format like "['CREATE_COMPLETE', 'UPDATE_COMPLETE']" """
     if not value:
@@ -79,7 +92,6 @@ def create_cluster_stack(config_file, region, template_version, debug):
             return
 
         # Load config to get template and version
-
         config_dir = Path(config_file).parent
         data, template, version = load_config(config_dir)
 
@@ -94,6 +106,11 @@ def create_cluster_stack(config_file, region, template_version, debug):
             # Create model instance and domain
             model_instance = model_class(**filtered_config)
             config = model_instance.to_config(region=region)
+
+            # Use newest template version if not provided
+            if template_version is None:
+                template_version = get_newest_template_version()
+                logger.info(f"No template version specified, using newest version: {template_version}")
 
             # Create the cluster stack
             stack_id = HpClusterStack(**config).create(region, template_version)

--- a/src/sagemaker/hyperpod/cli/commands/init.py
+++ b/src/sagemaker/hyperpod/cli/commands/init.py
@@ -11,6 +11,7 @@ from sagemaker.hyperpod.cli.constants.init_constants import (
     CFN
 )
 from sagemaker.hyperpod.cluster_management.hp_cluster_stack import HpClusterStack
+from sagemaker.hyperpod.cli.commands.cluster_stack import get_newest_template_version
 from sagemaker.hyperpod.cli.init_utils import (
     generate_click_command,
     save_config_yaml,
@@ -375,6 +376,10 @@ def _default_create(region, template_version):
             # Pass region to to_domain for cluster stack template
             if template == "cluster-stack":
                 config = template_model.to_config(region=region)
+                # Use newest template version if not provided
+                if template_version is None:
+                    template_version = get_newest_template_version()
+                    click.secho(f"No template version specified, using newest version: {template_version}", fg="yellow")
                 HpClusterStack(**config).create(region, template_version)
             else:
                 # Create from k8s.yaml

--- a/test/unit_tests/training/test_pytorch_job_template_model.py
+++ b/test/unit_tests/training/test_pytorch_job_template_model.py
@@ -1,0 +1,104 @@
+import unittest
+from hyperpod_pytorch_job_template.v1_1.model import PyTorchJobConfig
+
+
+class TestPyTorchJobConfigEFA(unittest.TestCase):
+    """Test EFA resource allocation in PyTorchJobConfig"""
+
+    def test_single_node_no_efa(self):
+        """Test that single-node jobs don't get EFA resources"""
+        config = PyTorchJobConfig(
+            job_name="test-single-node",
+            image="pytorch:latest",
+            node_count=1,
+            accelerators=2,
+            instance_type="ml.p4d.24xlarge"
+        )
+        
+        job = config.to_domain()
+        container = job.replicaSpecs[0].template.spec.containers[0]
+        
+        # Should not have EFA resources
+        self.assertNotIn("vpc.amazonaws.com/efa", container.resources.requests)
+        self.assertNotIn("vpc.amazonaws.com/efa", container.resources.limits)
+        
+        # Should have GPU resources
+        self.assertEqual(container.resources.requests["nvidia.com/gpu"], "2")
+
+    def test_multi_node_with_efa(self):
+        """Test that multi-node jobs automatically get EFA resources"""
+        config = PyTorchJobConfig(
+            job_name="test-multi-node",
+            image="pytorch:latest",
+            node_count=4,
+            accelerators=8,
+            instance_type="ml.p4d.24xlarge"
+        )
+        
+        job = config.to_domain()
+        container = job.replicaSpecs[0].template.spec.containers[0]
+        
+        # Should have EFA resources
+        self.assertEqual(container.resources.requests["vpc.amazonaws.com/efa"], "1")
+        self.assertEqual(container.resources.limits["vpc.amazonaws.com/efa"], "1")
+        
+        # Should also have GPU resources
+        self.assertEqual(container.resources.requests["nvidia.com/gpu"], "8")
+
+    def test_no_node_count_no_efa(self):
+        """Test that jobs without node_count don't get EFA resources"""
+        config = PyTorchJobConfig(
+            job_name="test-no-node-count",
+            image="pytorch:latest",
+            accelerators=1,
+            instance_type="ml.g5.xlarge"
+        )
+        
+        job = config.to_domain()
+        container = job.replicaSpecs[0].template.spec.containers[0]
+        
+        # Should not have EFA resources
+        self.assertNotIn("vpc.amazonaws.com/efa", container.resources.requests)
+        self.assertNotIn("vpc.amazonaws.com/efa", container.resources.limits)
+
+    def test_multi_node_with_memory_and_cpu(self):
+        """Test EFA with other resource types"""
+        config = PyTorchJobConfig(
+            job_name="test-multi-resources",
+            image="pytorch:latest",
+            node_count=2,
+            accelerators=4,
+            vcpu=16.0,
+            memory=64.0,
+            instance_type="ml.p4d.24xlarge"
+        )
+        
+        job = config.to_domain()
+        container = job.replicaSpecs[0].template.spec.containers[0]
+        
+        # Should have all resources including EFA
+        self.assertEqual(container.resources.requests["vpc.amazonaws.com/efa"], "1")
+        self.assertEqual(container.resources.requests["nvidia.com/gpu"], "4")
+        self.assertEqual(container.resources.requests["cpu"], "16.0")
+        self.assertEqual(container.resources.requests["memory"], "64.0Gi")
+
+    def test_accelerators_without_instance_type(self):
+        """Test that accelerators work without instance_type (fixes the main issue)"""
+        config = PyTorchJobConfig(
+            job_name="test-no-instance-type",
+            image="pytorch:latest",
+            accelerators=4
+            # No instance_type specified
+        )
+        
+        job = config.to_domain()
+        container = job.replicaSpecs[0].template.spec.containers[0]
+        
+        # Should respect accelerators value even without instance_type
+        self.assertEqual(container.resources.requests["nvidia.com/gpu"], "4")
+        # Limits should default to "0" since accelerators_limit not specified
+        self.assertEqual(container.resources.limits["nvidia.com/gpu"], "0")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What's changing and why?
<!-- Describe what you're changing and the motivation behind it -->
- https://github.com/aws/sagemaker-hyperpod-cli/issues/300
  - Fix: set `template-version` flag to optional for cluster create, also implemented a placeholder function to get the latest cluster template version. Would need a thorough implementation on this for follow-up.
- https://github.com/aws/sagemaker-hyperpod-cli/issues/306
  - Fix:  add support for EFA for pytorch job for multi-node jobs. When `node_count` > 1, `vpc.amazonaws.com/efa: 1` will be added to resource requests and limits
- https://github.com/aws/sagemaker-hyperpod-cli/issues/317
  - Fix:  remove the default setting request and limits to 0 when instance type is none

## Before/After UX
<!-- Show the user experience before and after your changes -->
**Before:**


**After:**


## How was this change tested?
<!-- Describe your testing approach -->


## Are unit tests added?


## Are integration tests added?


## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [ ] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only