### PR TITLE
Fix: hyp-pytorch-job init node-count & instance-type validation

### DIFF
--- a/src/sagemaker/hyperpod/training/quota_allocation_util.py
+++ b/src/sagemaker/hyperpod/training/quota_allocation_util.py
@@ -139,9 +139,9 @@ INSTANCE_RESOURCES = {
 
 def _has_compute_resource_quota_allocation_resources(memory_in_gib: Optional[float], vcpu: Optional[float], accelerators: Optional[int]) -> bool:
     return (
-        (memory_in_gib is not None) or
-        (vcpu is not None ) or
-        (accelerators is not None and accelerators > 0)  # Fix: treat accelerators=0 as not specified
+        (memory_in_gib is not None and memory_in_gib > 0) or
+        (vcpu is not None and vcpu > 0) or
+        (accelerators is not None and accelerators > 0)
     )
 
 # Gets resources from compute quotas that user provided; if not all provided, calculates defaults.

--- a/test/unit_tests/cli/test_quota_allocation_util.py
+++ b/test/unit_tests/cli/test_quota_allocation_util.py
@@ -52,10 +52,10 @@ class TestQuotaAllocationUtil:
             (16.0, None, 2, True),
             (None, 4.0, 2, True),
             (16.0, 4.0, 2, True),
-            # Zero values
-            (0, None, None, True),
-            (None, 0, None, True),
-            (None, None, 0, True),
+            # Zero values - all zeros treated as not specified for consistency
+            (0, None, None, False),
+            (None, 0, None, False),
+            (None, None, 0, False),
         ]
     )
     def test_has_gpu_quota_allocation_resources(self, memory_in_gib, vcpu, accelerators, expected):


### PR DESCRIPTION
## What's changing and why?
<!-- Describe what you're changing and the motivation behind it -->
- https://github.com/aws/sagemaker-hyperpod-cli/issues/315
  - Took me a while to be able to reproduce the error. It seems to me that for Python versions `3.12.11`-`3.13.3` (maybe a wider version), Pydantic validation has a different behavior: It is treating `accelerators=0` as not `None`. The fix is very simple.

## Before/After UX
<!-- Show the user experience before and after your changes -->
**Before:**


**After:**


## How was this change tested?
<!-- Describe your testing approach -->


## Are unit tests added?


## Are integration tests added?


## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [ ] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only