### PR TITLE
Instance types CRD changes

### DIFF
--- a/helm_chart/HyperPodHelmChart/Chart.yaml
+++ b/helm_chart/HyperPodHelmChart/Chart.yaml
@@ -81,7 +81,7 @@ dependencies:
     repository: "file://charts/team-role-and-bindings"
     condition: team-role-and-bindings.enabled
   - name: hyperpod-inference-operator
-    version: "1.2.0"
+    version: "1.3.0"
     repository: "file://charts/inference-operator"
     condition: inferenceOperators.enabled 
   - name: hyperpod-patching

--- a/helm_chart/HyperPodHelmChart/charts/inference-operator/Chart.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/inference-operator/Chart.yaml
@@ -19,7 +19,7 @@ version: 1.3.0
 
 # This is the version number of the application being deployed. Keep this aligned 
 # with operator image MAJOR.MINOR version.
-appVersion: "2.2"
+appVersion: "2.3"
 
 dependencies:
 - name: aws-mountpoint-s3-csi-driver

--- a/helm_chart/HyperPodHelmChart/charts/inference-operator/config/crd/inference.sagemaker.aws.amazon.com_inferenceendpointconfigs.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/inference-operator/config/crd/inference.sagemaker.aws.amazon.com_inferenceendpointconfigs.yaml
@@ -352,15 +352,15 @@ spec:
                 type: string
               instanceType:
                 description: |-
-                  Single instance type to deploy the model on.
-                  This field is mutually exclusive with instanceTypes. 
+	                Single instance type to deploy the model on.
+	                This field is mutually exclusive with instanceTypes. 
                   Use this when you want to deploy on a specific instance type.
                 pattern: ^ml\..*
                 type: string
               instanceTypes:
                 description: |-
-                  List of instance types to deploy the model on, in order of preference.
-                  Instance types are selected based on the order specified, selecting the first available type.
+	                List of instance types to deploy the model on, in order of preference.
+	                Instance types are selected based on the order specified, selecting the first available type.
                 items:
                   type: string
                 type: array
@@ -873,8 +873,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -930,6 +931,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -1505,7 +1543,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -1566,7 +1604,6 @@ spec:
                 - resources
                 type: object
             required:
-            - instanceType
             - modelName
             - modelSourceConfig
             - worker
@@ -1657,8 +1694,8 @@ spec:
                     description: Status of the Deployment Object
                     properties:
                       availableReplicas:
-                        description: Total number of available pods (ready for at
-                          least minReadySeconds) targeted by this deployment.
+                        description: Total number of available non-terminating pods
+                          (ready for at least minReadySeconds) targeted by this deployment.
                         format: int32
                         type: integer
                       collisionCount:
@@ -1711,13 +1748,21 @@ spec:
                         format: int64
                         type: integer
                       readyReplicas:
-                        description: readyReplicas is the number of pods targeted
+                        description: Total number of non-terminating pods targeted
                           by this Deployment with a Ready Condition.
                         format: int32
                         type: integer
                       replicas:
-                        description: Total number of non-terminated pods targeted
+                        description: Total number of non-terminating pods targeted
                           by this deployment (their labels match the selector).
+                        format: int32
+                        type: integer
+                      terminatingReplicas:
+                        description: |-
+                          Total number of terminating pods targeted by this deployment. Terminating pods have a non-null
+                          .metadata.deletionTimestamp and have not yet reached the Failed or Succeeded .status.phase.
+
+                          This is an alpha field. Enable DeploymentReplicaSetTerminatingReplicas to be able to use this field.
                         format: int32
                         type: integer
                       unavailableReplicas:
@@ -1728,7 +1773,7 @@ spec:
                         format: int32
                         type: integer
                       updatedReplicas:
-                        description: Total number of non-terminated pods targeted
+                        description: Total number of non-terminating pods targeted
                           by this deployment that have the desired template spec.
                         format: int32
                         type: integer
@@ -2226,8 +2271,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -2283,6 +2329,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -2390,7 +2473,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -2539,8 +2622,8 @@ spec:
                     description: Status of the Deployment Object
                     properties:
                       availableReplicas:
-                        description: Total number of available pods (ready for at
-                          least minReadySeconds) targeted by this deployment.
+                        description: Total number of available non-terminating pods
+                          (ready for at least minReadySeconds) targeted by this deployment.
                         format: int32
                         type: integer
                       collisionCount:
@@ -2593,13 +2676,21 @@ spec:
                         format: int64
                         type: integer
                       readyReplicas:
-                        description: readyReplicas is the number of pods targeted
+                        description: Total number of non-terminating pods targeted
                           by this Deployment with a Ready Condition.
                         format: int32
                         type: integer
                       replicas:
-                        description: Total number of non-terminated pods targeted
+                        description: Total number of non-terminating pods targeted
                           by this deployment (their labels match the selector).
+                        format: int32
+                        type: integer
+                      terminatingReplicas:
+                        description: |-
+                          Total number of terminating pods targeted by this deployment. Terminating pods have a non-null
+                          .metadata.deletionTimestamp and have not yet reached the Failed or Succeeded .status.phase.
+
+                          This is an alpha field. Enable DeploymentReplicaSetTerminatingReplicas to be able to use this field.
                         format: int32
                         type: integer
                       unavailableReplicas:
@@ -2610,7 +2701,7 @@ spec:
                         format: int32
                         type: integer
                       updatedReplicas:
-                        description: Total number of non-terminated pods targeted
+                        description: Total number of non-terminating pods targeted
                           by this deployment that have the desired template spec.
                         format: int32
                         type: integer

--- a/helm_chart/HyperPodHelmChart/charts/inference-operator/config/crd/inference.sagemaker.aws.amazon.com_jumpstartmodels.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/inference-operator/config/crd/inference.sagemaker.aws.amazon.com_jumpstartmodels.yaml
@@ -944,8 +944,8 @@ spec:
                     description: Status of the Deployment Object
                     properties:
                       availableReplicas:
-                        description: Total number of available pods (ready for at
-                          least minReadySeconds) targeted by this deployment.
+                        description: Total number of available non-terminating pods
+                          (ready for at least minReadySeconds) targeted by this deployment.
                         format: int32
                         type: integer
                       collisionCount:
@@ -998,13 +998,21 @@ spec:
                         format: int64
                         type: integer
                       readyReplicas:
-                        description: readyReplicas is the number of pods targeted
+                        description: Total number of non-terminating pods targeted
                           by this Deployment with a Ready Condition.
                         format: int32
                         type: integer
                       replicas:
-                        description: Total number of non-terminated pods targeted
+                        description: Total number of non-terminating pods targeted
                           by this deployment (their labels match the selector).
+                        format: int32
+                        type: integer
+                      terminatingReplicas:
+                        description: |-
+                          Total number of terminating pods targeted by this deployment. Terminating pods have a non-null
+                          .metadata.deletionTimestamp and have not yet reached the Failed or Succeeded .status.phase.
+
+                          This is an alpha field. Enable DeploymentReplicaSetTerminatingReplicas to be able to use this field.
                         format: int32
                         type: integer
                       unavailableReplicas:
@@ -1015,7 +1023,7 @@ spec:
                         format: int32
                         type: integer
                       updatedReplicas:
-                        description: Total number of non-terminated pods targeted
+                        description: Total number of non-terminating pods targeted
                           by this deployment that have the desired template spec.
                         format: int32
                         type: integer
@@ -1598,8 +1606,8 @@ spec:
                     description: Status of the Deployment Object
                     properties:
                       availableReplicas:
-                        description: Total number of available pods (ready for at
-                          least minReadySeconds) targeted by this deployment.
+                        description: Total number of available non-terminating pods
+                          (ready for at least minReadySeconds) targeted by this deployment.
                         format: int32
                         type: integer
                       collisionCount:
@@ -1652,13 +1660,21 @@ spec:
                         format: int64
                         type: integer
                       readyReplicas:
-                        description: readyReplicas is the number of pods targeted
+                        description: Total number of non-terminating pods targeted
                           by this Deployment with a Ready Condition.
                         format: int32
                         type: integer
                       replicas:
-                        description: Total number of non-terminated pods targeted
+                        description: Total number of non-terminating pods targeted
                           by this deployment (their labels match the selector).
+                        format: int32
+                        type: integer
+                      terminatingReplicas:
+                        description: |-
+                          Total number of terminating pods targeted by this deployment. Terminating pods have a non-null
+                          .metadata.deletionTimestamp and have not yet reached the Failed or Succeeded .status.phase.
+
+                          This is an alpha field. Enable DeploymentReplicaSetTerminatingReplicas to be able to use this field.
                         format: int32
                         type: integer
                       unavailableReplicas:
@@ -1669,7 +1685,7 @@ spec:
                         format: int32
                         type: integer
                       updatedReplicas:
-                        description: Total number of non-terminated pods targeted
+                        description: Total number of non-terminating pods targeted
                           by this deployment that have the desired template spec.
                         format: int32
                         type: integer

--- a/helm_chart/HyperPodHelmChart/charts/inference-operator/values.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/inference-operator/values.yaml
@@ -21,7 +21,7 @@ image:
     ap-southeast-4: 311141544681.dkr.ecr.ap-southeast-4.amazonaws.com
     ap-southeast-3: 158128612970.dkr.ecr.ap-southeast-3.amazonaws.com
     eu-south-2: 025050981094.dkr.ecr.eu-south-2.amazonaws.com
-  tag: v2.2
+  tag: v2.3
   pullPolicy: Always
   repository:
 hyperpodClusterArn:


### PR DESCRIPTION
Added support for multiple instance types in InferenceEndpointConfig by introducing a new optional instanceTypes field that allows specifying instance preferences in priority order. Made the original instanceType field optional to support this mutually exclusive deployment option.
