### PR TITLE
[BugFix] Instance types CRD remove tab to fix syntax

### DIFF
--- a/helm_chart/HyperPodHelmChart/charts/inference-operator/config/crd/inference.sagemaker.aws.amazon.com_inferenceendpointconfigs.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/inference-operator/config/crd/inference.sagemaker.aws.amazon.com_inferenceendpointconfigs.yaml
@@ -352,15 +352,15 @@ spec:
                 type: string
               instanceType:
                 description: |-
-	                Single instance type to deploy the model on.
-	                This field is mutually exclusive with instanceTypes. 
+                  Single instance type to deploy the model on.
+                  This field is mutually exclusive with instanceTypes. 
                   Use this when you want to deploy on a specific instance type.
                 pattern: ^ml\..*
                 type: string
               instanceTypes:
                 description: |-
-	                List of instance types to deploy the model on, in order of preference.
-	                Instance types are selected based on the order specified, selecting the first available type.
+                  List of instance types to deploy the model on, in order of preference.
+                  Instance types are selected based on the order specified, selecting the first available type.
                 items:
                   type: string
                 type: array


### PR DESCRIPTION
Fix the syntax error raised from this error from this PR: https://github.com/aws/sagemaker-hyperpod-cli/pull/362
```
Error: UPGRADE FAILED: YAML parse error on hyperpod-inference-operator/templates/default.yaml: error converting YAML to JSON: yaml: line 356: found a tab character where an indentation space is expected
```