### PR TITLE
feat(nova-evaluation): Add checkpoint_is_instruct_tuned to InferenceConfig

### DIFF
--- a/src/hyperpod_cli/validators/recipe_models/nova_evaluation/model.py
+++ b/src/hyperpod_cli/validators/recipe_models/nova_evaluation/model.py
@@ -35,6 +35,7 @@ class InferenceConfig(BaseModel):
     max_model_len: Optional[int|str] = None
     top_logprobs: Optional[int] = None
     reasoning_effort: Optional[str] = None
+    checkpoint_is_instruct_tuned: Optional[str] = None
 
 
 class RlEnvConfig(BaseModel):


### PR DESCRIPTION
## What's changing and why?
<!-- Describe what you're changing and the motivation behind it -->
This parameter is used during evaluation runs on CPT models. We need to add it here so validations pass when using SMHP. 
A customer tried to use this parameter which is supported by the evaluation container but got a validation error because it is not present here.
 
## Before/After UX
<!-- Show the user experience before and after your changes -->
**Before:**
Customer tries to use the new checkpoint_is_instruct_tuned = "false" parameter, but failed due to pydantic validation error since it's not here.
 
**After:**
Customer is able to set checkpoint_is_instruct_tuned = "false"  and run CPT evaluation.
 
## How was this change tested?
<!-- Describe your testing approach -->
We have verified that the checkpoint_is_instruct_tuned parameter works with the evaluation container internally.
 
## Are unit tests added?
No
 
## Are integration tests added?
No
 
## Reviewer Guidelines
 
‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 
 
One of the following must be true:
- [ ] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [] Changes are documentation-only