### PR TITLE
InferenceOperator Update hyperpod-inference-operator to 2.0.0 in HyperPodHelmChart

### DIFF
--- a/helm_chart/HyperPodHelmChart/Chart.yaml
+++ b/helm_chart/HyperPodHelmChart/Chart.yaml
@@ -81,7 +81,7 @@ dependencies:
     repository: "file://charts/team-role-and-bindings"
     condition: team-role-and-bindings.enabled
   - name: hyperpod-inference-operator
-    version: "1.3.0"
+    version: "2.0.0"
     repository: "file://charts/inference-operator"
     condition: inferenceOperators.enabled 
   - name: hyperpod-patching


### PR DESCRIPTION
## What's changing and why?
BugFix

Before 

### Parent Chart (Incorrect)
**File:** `helm_chart/HyperPodHelmChart/Chart.yaml`
**Line:** 84
**Current:**
```yaml
- name: hyperpod-inference-operator
  version: "1.3.0"  # :x: Wrong version
  repository: "file://charts/inference-operator"
  condition: inferenceOperators.enabled
```

After
### Subchart (Correct)
**File:** `helm_chart/HyperPodHelmChart/charts/inference-operator/Chart.yaml`
**Line:** 18
**Current:**
```yaml
version: 2.0.0  # :white_check_mark: Actual version
```

