### PR TITLE
feat: Add g7e instance types to HyperPod helm chart

### DIFF
--- a/helm_chart/HyperPodHelmChart/values.yaml
+++ b/helm_chart/HyperPodHelmChart/values.yaml
@@ -182,6 +182,12 @@ nvidia-device-plugin:
               - ml.g6e.16xlarge
               - ml.g6e.24xlarge
               - ml.g6e.48xlarge
+              - ml.g7e.2xlarge
+              - ml.g7e.4xlarge
+              - ml.g7e.8xlarge
+              - ml.g7e.12xlarge
+              - ml.g7e.24xlarge
+              - ml.g7e.48xlarge
               - ml.gr6.4xlarge
               - ml.gr6.8xlarge
               - ml.p4d.24xlarge
@@ -228,6 +234,10 @@ aws-efa-k8s-device-plugin:
       - ml.g6e.16xlarge
       - ml.g6e.24xlarge
       - ml.g6e.48xlarge
+      - ml.g7e.8xlarge
+      - ml.g7e.12xlarge
+      - ml.g7e.24xlarge
+      - ml.g7e.48xlarge
       - ml.gr6.8xlarge
       - ml.i3en.large
       - ml.i3en.xlarge


### PR DESCRIPTION
⚠️  DO NOT MERGE UNTIL WE HAVE GREENLIGHT RIGHT BEFORE LAUNCH TIME

## What's changing and why?

Adding g7e instance types to the HyperPod helm chart `values.yaml` to enable g7e support on EKS clusters.

Without this change, users cannot install the HyperPod helm charts on EKS clusters with g7e nodes because:
- The NVIDIA device plugin won't be scheduled on g7e nodes (missing from nodeAffinity)
- The EFA device plugin won't recognize EFA-capable g7e instances (missing from supportedInstanceLabels)

Changes:
- `nvidia-device-plugin` nodeAffinity: added all 6 g7e sizes (2xlarge, 4xlarge, 8xlarge, 12xlarge, 24xlarge, 48xlarge)
- `aws-efa-k8s-device-plugin` supportedInstanceLabels: added 4 EFA-capable g7e sizes (8xlarge, 12xlarge, 24xlarge, 48xlarge)

EFA support verified via `aws ec2 describe-instance-types`:
| Instance | EFA | Max EFA Interfaces |
|---|---|---|
| g7e.2xlarge | No | - |
| g7e.4xlarge | No | - |
| g7e.8xlarge | Yes | 1 |
| g7e.12xlarge | Yes | 1 |
| g7e.24xlarge | Yes | 2 |
| g7e.48xlarge | Yes | 4 |

## Before/After UX

**Before:** Helm chart installation on g7e EKS clusters results in NVIDIA device plugin pods not being scheduled on g7e nodes, and EFA devices not being recognized.

**After:** NVIDIA device plugin is correctly scheduled on all g7e nodes, and EFA device plugin recognizes EFA-capable g7e instances.

## How was this change tested?

Config-only change (YAML values). Verified instance types and EFA support via `aws ec2 describe-instance-types`.

## Are unit tests added?

N/A — config-only change, no code logic modified.

## Are integration tests added?

N/A — config-only change.

## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification.

One of the following must be true:
- [x] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only