### PR TITLE
feat: Add g7e instance types to health-monitoring-agent node affinity

### DIFF
--- a/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/templates/health-monitoring-agent.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/templates/health-monitoring-agent.yaml
@@ -104,6 +104,12 @@ spec:
                       - ml.g6e.12xlarge
                       - ml.g6e.24xlarge
                       - ml.g6e.48xlarge
+                      - ml.g7e.2xlarge
+                      - ml.g7e.4xlarge
+                      - ml.g7e.8xlarge
+                      - ml.g7e.12xlarge
+                      - ml.g7e.24xlarge
+                      - ml.g7e.48xlarge
                       - ml.p6-b200.48xlarge
                       - ml.p6e-gb200.36xlarge
       containers:


### PR DESCRIPTION
⚠️ DO NOT MERGE UNTIL WE HAVE GREENLIGHT RIGHT BEFORE LAUNCH TIME

## What's changing and why?

Adding g7e instance types (ml.g7e.{2,4,8,12,24,48}xlarge) to the health-monitoring-agent DaemonSet node affinity allowlist. Without this change, the health monitoring agent won't be scheduled on g7e nodes, meaning no health monitoring on g7e instances.

Part of g7e instance type onboarding for HyperPod.
Related PR: #380

## Before/After UX

**Before:** Health monitoring agent pods are not scheduled on g7e nodes because the node affinity doesn't include g7e instance types. g7e nodes have no health monitoring coverage.

**After:** Health monitoring agent pods are correctly scheduled on all g7e nodes via node affinity matching.

## How was this change tested?

Config-only change — added g7e instance types to the YAML node affinity values list. No logic changes.

## Are unit tests added?

N/A — config-only change, no code logic modified.

## Are integration tests added?

N/A — config-only change.

## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification.

One of the following must be true:
- [x] Changes are documentation-only