### PR TITLE
feat: add new field source to Nova config

### DIFF
--- a/src/hyperpod_cli/validators/recipe_models/nova/model.py
+++ b/src/hyperpod_cli/validators/recipe_models/nova/model.py
@@ -12,6 +12,7 @@ class RunConfig(BaseModel):
     data_s3_path: Optional[str] = None
     output_s3_path: Optional[str] = None
     validation_data_s3_path: Optional[str] = None
+    source : Optional[str] = None
 
     # PPO-specific replica configurations
     actor_train_replicas: Optional[int|str] = None


### PR DESCRIPTION
## What's changing and why?
* Nova recipes are adding a new field called `source` under the `run` config to contain what source triggered the SMHP job for Nova models. I am adjusting the validation to accept this new field.

Change is not needed on mainline branch at this point as Nova Forge SDK has a dependency on the V2 package version. 

## Before/After UX
<!-- Show the user experience before and after your changes -->
**Before:**

User who pass a `source` field under `run` for Nova recipes failed validation.

**After:**

User who pass a `source` field under `run` for Nova recipes pass validation.

User experience will not change for users who directly use the Sagemaker Hyperpod CLI, as no recipes in the sagemaker-hyperpod-recipes package will change. 

However, for customers who use the Nova Forge SDK, the Nova Forge SDK will populate this field in their recipe for SMHP Nova recipes.

## How was this change tested?

Locally tested this change and validating that the training images supported this field. 


## Are unit tests added?

No


## Are integration tests added?

No


## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [x] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only