### PR TITLE
Fix missing ml. prefix and wrong MIG profiles for p6-b200.48xlarge

### DIFF
--- a/src/sagemaker/hyperpod/inference/constant.py
+++ b/src/sagemaker/hyperpod/inference/constant.py
@@ -39,13 +39,13 @@ INSTANCE_MIG_PROFILES = {
         "mig-4g.71gb",
         "mig-7g.141gb"
     ],
-    "p6-b200.48xlarge": [
+    "ml.p6-b200.48xlarge": [
         "mig-1g.23gb",
-        "mig-1g.47gb",
-        "mig-2g.47gb",
-        "mig-3g.93gb",
-        "mig-4g.93gb",
-        "mig-7g.186gb"
+        "mig-1g.45gb",
+        "mig-2g.45gb",
+        "mig-3g.90gb",
+        "mig-4g.90gb",
+        "mig-7g.180gb"
     ],
     "ml.p6e-gb200.36xlarge": [
         "mig-1g.23gb",

--- a/src/sagemaker/hyperpod/training/constants.py
+++ b/src/sagemaker/hyperpod/training/constants.py
@@ -131,7 +131,7 @@ INSTANCE_TYPE_MIG_PROFILES = {
     'ml.p5.48xlarge': ['mig-1g.10gb', 'mig-1g.20gb', 'mig-2g.20gb', 'mig-3g.40gb', 'mig-4g.40gb', 'mig-7g.80gb'],
     'ml.p5e.48xlarge': ['mig-1g.18gb', 'mig-1g.35gb', 'mig-2g.35gb', 'mig-3g.71gb', 'mig-4g.71gb', 'mig-7g.141gb'],
     'ml.p5en.48xlarge': ['mig-1g.18gb', 'mig-1g.35gb', 'mig-2g.35gb', 'mig-3g.71gb', 'mig-4g.71gb', 'mig-7g.141gb'],
-    'p6-b200.48xlarge': ['mig-1g.23gb', 'mig-1g.45gb', 'mig-2g.45gb', 'mig-3g.90gb', 'mig-4g.90gb', 'mig-7g.180gb'],
+    'ml.p6-b200.48xlarge': ['mig-1g.23gb', 'mig-1g.45gb', 'mig-2g.45gb', 'mig-3g.90gb', 'mig-4g.90gb', 'mig-7g.180gb'],
     'ml.p6e-gb200.36xlarge': ['mig-1g.23gb', 'mig-1g.47gb', 'mig-2g.47gb', 'mig-3g.93gb', 'mig-4g.93gb', 'mig-7g.186gb'],
     'ml.g7e.2xlarge': ['mig-1g.24gb', 'mig-2g.48gb', 'mig-4g.96gb'],
     'ml.g7e.4xlarge': ['mig-1g.24gb', 'mig-2g.48gb', 'mig-4g.96gb'],

--- a/test/unit_tests/inference/test_hp_jumpstart_endpoint.py
+++ b/test/unit_tests/inference/test_hp_jumpstart_endpoint.py
@@ -397,7 +397,7 @@ class TestHPJumpStartEndpoint(unittest.TestCase):
             ("ml.p5.48xlarge", "mig-3g.40gb"),
             ("ml.p5e.48xlarge", "mig-1g.18gb"),
             ("ml.p5en.48xlarge", "mig-7g.141gb"),
-            ("p6-b200.48xlarge", "mig-1g.23gb"),
+            ("ml.p6-b200.48xlarge", "mig-1g.23gb"),
             ("ml.p6e-gb200.36xlarge", "mig-7g.186gb"),
         ]
 


### PR DESCRIPTION
## Summary

Fix three bugs in the `p6-b200.48xlarge` MIG profile configuration that cause MIG validation to always reject B200 instances for both training and inference workloads.

## Bugs Fixed

### 1. Training: missing `ml.` prefix in `INSTANCE_TYPE_MIG_PROFILES`

**File:** `src/sagemaker/hyperpod/training/constants.py:134`

The dict key is `'p6-b200.48xlarge'` but the instance type flowing through the system from `node.kubernetes.io/instance-type` is always `ml.p6-b200.48xlarge`. The lookup at `accelerator_partition_util.py:26` fails, returning:

```
"Instance type 'ml.p6-b200.48xlarge' does not support accelerator partitions."
```

This blocks all B200 MIG usage: `HyperPodPyTorchJob` submissions with `acceleratorPartitionType` and `hyp list-accelerator-partition-type --instance-type ml.p6-b200.48xlarge`.

Every other entry in the dict uses the `ml.` prefix. The enum in `hyperpod_instance_types.py:110` also defines `ML_P6_B200_48XLARGE = "ml.p6-b200.48xlarge"`.

### 2. Inference: missing `ml.` prefix in `INSTANCE_MIG_PROFILES`

**File:** `src/sagemaker/hyperpod/inference/constant.py:42`

Same key mismatch as above. `hp_jumpstart_endpoint.py:287` checks `instance_type not in INSTANCE_MIG_PROFILES`, which always fails for B200 when the caller passes the correct `ml.p6-b200.48xlarge`.

### 3. Inference: wrong MIG profiles for B200 (copy-pasted from GB200)

**File:** `src/sagemaker/hyperpod/inference/constant.py:43-48`

The B200 entry had GB200 profiles instead of B200 profiles:

| Profile slot | Was (GB200 values) | Now (correct B200 values) |
|:---:|:---:|:---:|
| 1g double-mem | `mig-1g.47gb` | `mig-1g.45gb` |
| 2g | `mig-2g.47gb` | `mig-2g.45gb` |
| 3g | `mig-3g.93gb` | `mig-3g.90gb` |
| 4g | `mig-4g.93gb` | `mig-4g.90gb` |
| 7g | `mig-7g.186gb` | `mig-7g.180gb` |

The correct B200 profiles are confirmed by the [NVIDIA MIG User Guide (r580)](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/supported-mig-profiles.html) and the [NVIDIA GPU Operator upstream ConfigMap](https://github.com/NVIDIA/gpu-operator/blob/main/assets/state-mig-manager/0400_configmap.yaml) (device-filter `0x290110DE`).

## Changes

| File | Change |
|------|--------|
| `src/sagemaker/hyperpod/training/constants.py` | `'p6-b200.48xlarge'` → `'ml.p6-b200.48xlarge'` |
| `src/sagemaker/hyperpod/inference/constant.py` | Key prefix fix + correct B200 profiles |
| `test/unit_tests/inference/test_hp_jumpstart_endpoint.py` | Update test to use `ml.p6-b200.48xlarge` |

## Test plan

- [ ] Verify `INSTANCE_TYPE_MIG_PROFILES['ml.p6-b200.48xlarge']` returns the correct 6 B200 profiles
- [ ] Verify `INSTANCE_MIG_PROFILES['ml.p6-b200.48xlarge']` returns the correct 7 B200 profiles
- [ ] Verify `_validate_accelerator_partition("mig-1g.23gb", ..., "ml.p6-b200.48xlarge")` passes validation
- [ ] Verify `validate_mig_profile("mig-1g.45gb", "ml.p6-b200.48xlarge")` passes in inference
- [ ] Unit test: `test_hp_jumpstart_endpoint.py` passes with updated instance type