### PR TITLE
Introduce replica_count support for training and deprecate node_count (#383)

### DIFF
--- a/hyperpod-pytorch-job-template/hyperpod_pytorch_job_template/v1_1/model.py
+++ b/hyperpod-pytorch-job-template/hyperpod_pytorch_job_template/v1_1/model.py
@@ -134,7 +134,13 @@ class PyTorchJobConfig(BaseModel):
     node_count: Optional[int] = Field(
         default=None,
         alias="node_count", 
-        description="Number of nodes",
+        description="[DEPRECATED] Number of nodes. Use replica_count instead.",
+        ge=1
+    )
+    replica_count: Optional[int] = Field(
+        default=None,
+        alias="replica_count",
+        description="Number of job replicas",
         ge=1
     )
     tasks_per_node: Optional[str] = Field(
@@ -259,7 +265,13 @@ class PyTorchJobConfig(BaseModel):
     max_node_count: Optional[int] = Field(
         default=None,
         alias="max_node_count",
-        description="Maximum number of nodes for elastic training",
+        description="[DEPRECATED] Maximum number of nodes for elastic training. Use max_replica_count instead.",
+        ge=1,
+    )
+    max_replica_count: Optional[int] = Field(
+        default=None,
+        alias="max_replica_count",
+        description="Maximum number of replicas for elastic training",
         ge=1,
     )
     elastic_graceful_shutdown_timeout_in_seconds: Optional[int] = Field(
@@ -402,11 +414,32 @@ class PyTorchJobConfig(BaseModel):
             return self
 
         valid, error = _validate_accelerator_partition_parameters(
-            self.accelerator_partition_type, self.accelerators, self.accelerators_limit, self.node_count, self.instance_type
+            self.accelerator_partition_type, self.accelerators, self.accelerators_limit,
+            self.replica_count or self.node_count, self.instance_type
         )
         if not valid:
             raise ValueError(error)
         
+        return self
+
+    @model_validator(mode='after')
+    def validate_replica_params(self):
+        """Validate replica_count / node_count and max_replica_count / max_node_count usage."""
+        if self.replica_count is not None and self.node_count is not None:
+            raise ValueError("Only one of 'replica_count' or 'node_count' can be specified, not both.")
+        if self.max_replica_count is not None and self.max_node_count is not None:
+            raise ValueError("Only one of 'max_replica_count' or 'max_node_count' can be specified, not both.")
+        # node_count implies full-node allocation, so it can't be combined with granular resources
+        if self.node_count is not None:
+            has_resources = any([
+                self.accelerators, self.vcpu, self.memory,
+                self.accelerators_limit, self.vcpu_limit, self.memory_limit,
+            ])
+            if has_resources:
+                raise ValueError(
+                    "node_count cannot be combined with resource fields (accelerators, vcpu, memory). "
+                    "Use replica_count instead to specify replicas with granular resources."
+                )
         return self
 
     @model_validator(mode='after')
@@ -435,14 +468,14 @@ class PyTorchJobConfig(BaseModel):
                     f"Got: {discrete_values}"
                 )
 
-            # Check against max_node_count if specified
-            if self.max_node_count is not None:
-                invalid_values = [val for val in discrete_values if val > self.max_node_count]
+            # Check against max replicas if specified
+            max_reps = self.max_replica_count or self.max_node_count
+            if max_reps is not None:
+                invalid_values = [val for val in discrete_values if val > max_reps]
                 if invalid_values:
                     raise ValueError(
-                        f"All values in 'elastic_replica_discrete_values' must be ≤ max_node_count ({self.max_node_count}). "
-                        f"Invalid values: {invalid_values}. "
-                        f"Please either increase max_node_count or remove values exceeding it."
+                        f"All values in 'elastic_replica_discrete_values' must be <= max replica count ({max_reps}). "
+                        f"Invalid values: {invalid_values}."
                     )
 
         return self
@@ -450,6 +483,10 @@ class PyTorchJobConfig(BaseModel):
     def to_domain(self) -> Dict:
         """Convert flat config to domain model (HyperPodPytorchJobSpec)"""
         
+        # Resolve deprecated aliases
+        replicas = self.replica_count or self.node_count
+        max_replicas = self.max_replica_count or self.max_node_count
+
         # Helper function to build dict with non-None values
         def build_dict(**kwargs):
             return {k: v for k, v in kwargs.items() if v is not None}
@@ -553,23 +590,23 @@ class PyTorchJobConfig(BaseModel):
         replica_kwargs = build_dict(
             name="pod",
             template=Template(metadata=Metadata(**metadata_kwargs), spec=Spec(**spec_kwargs)),
-            replicas=self.node_count,
-            max_replicas=self.max_node_count
+            replicas=replicas,
+            max_replicas=max_replicas
         )
 
         # Build elastic policy
         elastic_policy = None
         if any([
             self.elastic_replica_increment_step is not None,
-            self.max_node_count is not None,
+            max_replicas is not None,
             self.elastic_graceful_shutdown_timeout_in_seconds is not None,
             self.elastic_scaling_timeout_in_seconds is not None,
             self.elastic_replica_discrete_values is not None
         ]):
             # Build base elastic policy kwargs
             elastic_policy_kwargs = build_dict(
-                min_replicas=self.node_count,
-                max_replicas=self.max_node_count,
+                min_replicas=replicas,
+                max_replicas=max_replicas,
                 graceful_shutdown_timeout_in_seconds=self.elastic_graceful_shutdown_timeout_in_seconds,
                 scaling_timeout_in_seconds=self.elastic_scaling_timeout_in_seconds
             )

--- a/hyperpod-pytorch-job-template/hyperpod_pytorch_job_template/v1_1/schema.json
+++ b/hyperpod-pytorch-job-template/hyperpod_pytorch_job_template/v1_1/schema.json
@@ -199,8 +199,23 @@
         }
       ],
       "default": null,
-      "description": "Number of nodes",
+      "deprecated": true,
+      "description": "[DEPRECATED] Number of nodes. Use replica_count instead.",
       "title": "Node Count"
+    },
+    "replica_count": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Number of job replicas",
+      "title": "Replica Count"
     },
     "tasks_per_node": {
       "anyOf": [
@@ -431,8 +446,23 @@
         }
       ],
       "default": null,
-      "description": "Maximum number of nodes for elastic training",
+      "deprecated": true,
+      "description": "[DEPRECATED] Maximum number of nodes for elastic training. Use max_replica_count instead.",
       "title": "Max Node Count"
+    },
+    "max_replica_count": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Maximum number of replicas for elastic training",
+      "title": "Max Replica Count"
     },
     "elastic_graceful_shutdown_timeout_in_seconds": {
       "anyOf": [

--- a/hyperpod-pytorch-job-template/hyperpod_pytorch_job_template/v1_1/template.py
+++ b/hyperpod-pytorch-job-template/hyperpod_pytorch_job_template/v1_1/template.py
@@ -28,8 +28,8 @@ spec:
 {%- endif %}
   replicaSpecs:
     - name: pod
-    {%- if node_count %}
-      replicas: {{ node_count }}
+    {%- if replica_count or node_count %}
+      replicas: {{ replica_count or node_count }}
     {%- endif %}
       template:
         metadata:

--- a/src/sagemaker/hyperpod/cli/init_utils.py
+++ b/src/sagemaker/hyperpod/cli/init_utils.py
@@ -519,6 +519,8 @@ def build_config_from_schema(template: str, version: str, model_config=None, exi
     
     for key in props:
         if key not in reqs and key not in excluded_fields:
+            if props[key].get("deprecated"):
+                continue
             full_cfg[key] = values.get(key, None)
     
     # Build comment map with [Required] prefix for required fields
@@ -528,6 +530,8 @@ def build_config_from_schema(template: str, version: str, model_config=None, exi
     }
     for key, spec in props.items():
         if key not in excluded_fields:
+            if spec.get("deprecated"):
+                continue
             desc = spec.get("description", "")
             if key in reqs:
                 desc = f"[Required] {desc}"

--- a/src/sagemaker/hyperpod/training/hyperpod_pytorch_job.py
+++ b/src/sagemaker/hyperpod/training/hyperpod_pytorch_job.py
@@ -120,7 +120,7 @@ class HyperPodPytorchJob(_HyperPodPytorchJob):
             has_accelerators = any(requests.get(k) and str(requests.get(k)) != "0" for k in accel_keys)
             has_accelerators_limit = any(limits.get(k) and str(limits.get(k)) != "0" for k in accel_keys)
             if not instance_type and (has_accelerators or has_accelerators_limit):
-                raise ValueError("--instance-type is required when specifying accelerator resources")
+                raise ValueError("instance_type is required when specifying accelerator resources")
 
             if not instance_type:
                 return None
@@ -441,7 +441,7 @@ class HyperPodPytorchJob(_HyperPodPytorchJob):
             else:
                 if pod not in pods:
                     logger.error(f"Pod {pod} not found in job {job_name}")
-                    raise ValueError(f"Pod {pod} not found in job {job_name}")
+                    raise ValueError(f"Pod '{pod}' not found in job '{job_name}'")
 
                 result = self._exec_command_on_pod(pod, command, container)
                 logger.info(f"Successfully executed command on pod {pod}")

--- a/src/sagemaker/hyperpod/training/quota_allocation_util.py
+++ b/src/sagemaker/hyperpod/training/quota_allocation_util.py
@@ -166,7 +166,7 @@ def _resolve_default_cpu_values(instance_type: str, requests_values: dict) -> No
     if cpu_request is not None and cpu_request > total_available_cpu:
         raise ValueError(
             f"Specified CPU request ({cpu_request}) exceeds instance capacity. "
-            f"Maximum available CPU for {instance_type} is {total_available_cpu}."
+            f"Maximum available CPU for '{instance_type}' is {total_available_cpu}."
         )
 
     max_allocatable_cpu = int(total_available_cpu - _calculate_cpu_reservation(total_available_cpu))
@@ -194,7 +194,7 @@ def _resolve_default_memory_values(instance_type: str, requests_values: dict, li
     if memory_request > total_available_memory:
         raise ValueError(
             f"Specified memory request ({memory_request}Gi) exceeds instance capacity. "
-            f"Maximum available memory for {instance_type} is {total_available_memory}Gi."
+            f"Maximum available memory for '{instance_type}' is {total_available_memory}Gi."
         )
 
     max_allocatable_memory = int(total_available_memory - _calculate_memory_reservation(total_available_memory))
@@ -211,16 +211,16 @@ def _validate_accelerators_inputs(instance_type: str, accelerators_request: int,
     type_of_accelerator, _max_accelerator_per_instance = _get_accelerator_type_and_count(instance_type)
     if type_of_accelerator is None and (accelerators_request is not None or accelerators_limit is not None):
         raise ValueError(
-            f"Instance type {instance_type} does not support accelerators, but accelerator values were provided.")
+            f"Instance type '{instance_type}' does not support accelerators, but accelerator values were provided.")
 
     if type_of_accelerator is not None:
         if accelerators_request is not None and accelerators_limit is not None:
             if accelerators_request !=  accelerators_limit:
                 raise ValueError('Accelerator request must equal accelerator limit')
             if accelerators_limit > _max_accelerator_per_instance:
-                raise ValueError('Requested accelerators exceeds capacity')
+                raise ValueError(f'Requested accelerator limit ({accelerators_limit}) exceeds instance capacity ({_max_accelerator_per_instance})')
             if accelerators_request > _max_accelerator_per_instance:
-                raise ValueError('Requested accelerators exceeds capacity')
+                raise ValueError(f'Requested accelerators ({accelerators_request}) exceeds instance capacity ({_max_accelerator_per_instance})')
 
 
 def _validate_efa_inputs(instance_type: str, efa_interfaces: Optional[int], efa_interfaces_limit: Optional[int]) -> None:
@@ -231,7 +231,7 @@ def _validate_efa_inputs(instance_type: str, efa_interfaces: Optional[int], efa_
     # Check if user provided EFA values but instance doesn't support EFA
     if max_efa_per_instance == 0 and (efa_interfaces is not None or efa_interfaces_limit is not None):
         raise ValueError(
-            f"Instance type {instance_type} does not support EFA, but EFA values were provided.")
+            f"Instance type '{instance_type}' does not support EFA, but EFA values were provided.")
 
     # Validate EFA values if instance supports EFA
     if max_efa_per_instance > 0:
@@ -277,17 +277,11 @@ def _is_valid(vcpu: Optional[float], memory_in_gib: Optional[float], accelerator
     has_gpu_quota_allocation = _has_compute_resource_quota_allocation_resources(memory_in_gib, vcpu, accelerators)
 
     if (instance_type is None and has_gpu_quota_allocation) or (instance_type is None and accelerator_partition_type):
-        return False, "Instance-type must be specified when accelerators, accelerator_partition_type, vcpu, or memory-in-gib specified"
-
-    node_specified = node_count is not None and node_count > 0
+        return False, "instance_type is required when specifying accelerators, accelerator_partition_type, vcpu, or memory"
 
     # Check if instance_type is valid only when it's provided
     if instance_type is not None and (INSTANCE_RESOURCES.get(instance_type) is None):
-        return False, f"Invalid instance-type {instance_type}. Please re-check the instance type and contact AWS for support."
-    if instance_type is not None:
-        #both resources and node count specified
-        if (has_gpu_quota_allocation and node_specified):
-            return False, f"Either node-count OR a combination of accelerators, vcpu, memory-in-gib must be specified for instance-type {instance_type}"
+        return False, f"Invalid instance_type '{instance_type}'. Please re-check the instance type and contact AWS for support."
     return True, ""
 
 

--- a/test/integration_tests/training/cli/test_gpu_quota_allocation.py
+++ b/test/integration_tests/training/cli/test_gpu_quota_allocation.py
@@ -209,7 +209,7 @@ class TestGpuQuotaAllocationIntegration:
         logger.info(f"Successfully deleted job: {test_job_name}")
 
     def test_invalid_node_count_accelerators_parameter(self, test_job_name):
-        """Test that invalid case where both node-count and accelerators are provided"""
+        """Test that node-count cannot be combined with resource fields"""
 
         # Test with both node-count and accelerators parameters
         create_cmd = [
@@ -236,8 +236,7 @@ class TestGpuQuotaAllocationIntegration:
                     text=True
                 )
         assert result.returncode != 0
-        assert "Either node-count OR a combination of accelerators, vcpu, " in result.stdout
-        assert "memory-in-gib must be specified for instance-type ml.g5.8xlarge" in result.stdout
+        assert "node_count cannot be combined with resource fields" in result.stdout
 
     def test_invalid_no_node_count_or_quota_parameter(self, test_job_name):
         """Test that case where both node-count and any of the quota parameters are provided"""
@@ -297,5 +296,5 @@ class TestGpuQuotaAllocationIntegration:
             text=True
         )
         assert result.returncode != 0
-        assert "Invalid instance-type ml.n5.8xlarge" in result.stdout
+        assert "Invalid instance_type" in result.stdout
         logger.info("Successfully verified invalid instance type error")

--- a/test/integration_tests/training/cli/test_gpu_quota_allocation.py
+++ b/test/integration_tests/training/cli/test_gpu_quota_allocation.py
@@ -236,7 +236,7 @@ class TestGpuQuotaAllocationIntegration:
                     text=True
                 )
         assert result.returncode != 0
-        assert "node_count cannot be combined with resource fields" in result.stdout
+        assert "node_count cannot be combined with resource fields" in result.stderr
 
     def test_invalid_no_node_count_or_quota_parameter(self, test_job_name):
         """Test that case where both node-count and any of the quota parameters are provided"""
@@ -286,7 +286,7 @@ class TestGpuQuotaAllocationIntegration:
             "--accelerators-limit", "1",
             "--vcpu-limit", "4",
             "--memory-limit", "2",
-            "--node-count", "1",
+            "--replica-count", "1",
             "--queue-name", QUEUE,
             "--namespace", NAMESPACE
         ]

--- a/test/integration_tests/training/sdk/test_sdk_quota_allocation.py
+++ b/test/integration_tests/training/sdk/test_sdk_quota_allocation.py
@@ -248,7 +248,7 @@ class TestHyperPodSDKQuotaAllocation:
         )
 
         # This should raise a ValueError for invalid instance type
-        with pytest.raises(ValueError, match="Invalid instance-type"):
+        with pytest.raises(ValueError, match="Invalid instance_type"):
             pytorch_job.create()
 
     def test_default_replicas_allocation(self, test_job_name, image_uri):
@@ -506,7 +506,7 @@ class TestHyperPodSDKQuotaAllocation:
             run_policy=RunPolicy(clean_pod_policy="None"),
         )
 
-        with pytest.raises(ValueError, match="Requested accelerators exceeds capacity"):
+        with pytest.raises(ValueError, match="Requested accelerator limit .* exceeds instance capacity"):
             pytorch_job.create()
 
     def test_set_default_accelerators_val_missing_request(self, test_job_name, image_uri):

--- a/test/unit_tests/cli/test_quota_allocation_util.py
+++ b/test/unit_tests/cli/test_quota_allocation_util.py
@@ -209,17 +209,17 @@ class TestQuotaAllocationUtil:
     def test_is_valid_no_instance_type_with_resources(self):
         valid, message = _is_valid(4.0, 16.0, None, None, None, None)
         assert not valid
-        assert message == "Instance-type must be specified when accelerators, accelerator_partition_type, vcpu, or memory-in-gib specified"
+        assert message == "instance_type is required when specifying accelerators, accelerator_partition_type, vcpu, or memory"
 
     def test_is_valid_invalid_instance_type(self):
         valid, message = _is_valid(None, None, None, None, 1, "ml-123")
         assert not valid
-        assert message == "Invalid instance-type ml-123. Please re-check the instance type and contact AWS for support."
+        assert message == "Invalid instance_type 'ml-123'. Please re-check the instance type and contact AWS for support."
 
     def test_is_valid_both_node_count_and_resources(self):
         valid, message = _is_valid(4.0, None, None, None, 2, "ml.g5.xlarge")
-        assert not valid
-        assert message == "Either node-count OR a combination of accelerators, vcpu, memory-in-gib must be specified for instance-type ml.g5.xlarge"
+        assert valid
+        assert message == ""
 
     def test_is_valid_both_node_count_and_limits(self):
         valid, message = _is_valid(None, None, None, None, 2, "ml.g5.xlarge")
@@ -325,7 +325,7 @@ class TestQuotaAllocationUtil:
             _validate_accelerators_inputs("ml.g5.xlarge", 1, 2)
 
     def test_validate_accelerators_inputs_exceeds_capacity_request(self):
-        with pytest.raises(ValueError, match="Requested accelerators exceeds capacity"):
+        with pytest.raises(ValueError, match="Requested accelerator limit .* exceeds instance capacity"):
             _validate_accelerators_inputs("ml.g5.xlarge", 2, 2)
 
     def test_validate_accelerators_inputs_exceeds_capacity_limit(self):
@@ -333,7 +333,7 @@ class TestQuotaAllocationUtil:
             _validate_accelerators_inputs("ml.g5.xlarge", 1, 2)
 
     def test_validate_accelerators_inputs_cpu_only_instance(self):
-        with pytest.raises(ValueError, match="Instance type ml.c5.large does not support accelerators, but accelerator values were provided."):
+        with pytest.raises(ValueError, match="Instance type 'ml.c5.large' does not support accelerators, but accelerator values were provided."):
             _validate_accelerators_inputs("ml.c5.large", 1, 1)
 
     # Tests for _set_default_accelerators_val
@@ -365,7 +365,7 @@ class TestQuotaAllocationUtil:
     def test_resolve_default_cpu_request_exceeds_capacity(self):
         requests_values = {"cpu": "10.0"}
         limits_values = {}
-        with pytest.raises(ValueError, match=re.escape("Specified CPU request (10.0) exceeds instance capacity. Maximum available CPU for ml.g5.2xlarge is 8.")):
+        with pytest.raises(ValueError, match=re.escape("Specified CPU request (10.0) exceeds instance capacity. Maximum available CPU for 'ml.g5.2xlarge' is 8.")):
             _resolve_default_cpu_values("ml.g5.2xlarge", requests_values)
 
     # Tests for _resolve_default_cpu_values
@@ -386,7 +386,7 @@ class TestQuotaAllocationUtil:
     def test_resolve_default_cpu_values_exceeds_instance_capacity(self):
         requests_values = {"cpu": "10.0"}
         limits_values = {}
-        with pytest.raises(ValueError, match=re.escape("Specified CPU request (10.0) exceeds instance capacity. Maximum available CPU for ml.c5.large is 2.")):
+        with pytest.raises(ValueError, match=re.escape("Specified CPU request (10.0) exceeds instance capacity. Maximum available CPU for 'ml.c5.large' is 2.")):
             _resolve_default_cpu_values("ml.c5.large", requests_values)
 
     # Tests for trimming request values

--- a/test/unit_tests/training/test_pytorch_job_template_model.py
+++ b/test/unit_tests/training/test_pytorch_job_template_model.py
@@ -2,7 +2,7 @@ import unittest
 from hyperpod_pytorch_job_template.v1_1.model import PyTorchJobConfig
 from hyperpod_pytorch_job_template.v1_0.model import PyTorchJobConfig as PyTorchJobConfigV1_0
 from hyperpod_pytorch_job_template.v1_1.template import TEMPLATE_CONTENT
-from jinja2 import Template
+from jinja2 import Template as JinjaTemplate
 from sagemaker.hyperpod.training.hyperpod_pytorch_job import HyperPodPytorchJob
 
 
@@ -93,7 +93,7 @@ class TestResourceAllocation(unittest.TestCase):
             )],
         )
 
-        with self.assertRaises(ValueError, msg="--instance-type is required when specifying accelerator resources"):
+        with self.assertRaises(ValueError, msg="instance_type is required when specifying accelerator resources"):
             HyperPodPytorchJob.allocate_quotas_if_applicable(job)
 
 
@@ -102,7 +102,7 @@ class TestJinjaTemplateRendering(unittest.TestCase):
 
     def test_all_resource_fields_render_in_template(self):
         """Verify all schema resource fields are correctly rendered by the jinja template."""
-        template = Template(TEMPLATE_CONTENT)
+        template = JinjaTemplate(TEMPLATE_CONTENT)
         rendered = template.render(
             job_name="test-resources",
             namespace="default",
@@ -159,7 +159,7 @@ class TestJinjaTemplateRendering(unittest.TestCase):
 
     def test_accelerator_partition_fields_render_in_template(self):
         """Verify accelerator partition fields render correctly (mutually exclusive with accelerators)."""
-        template = Template(TEMPLATE_CONTENT)
+        template = JinjaTemplate(TEMPLATE_CONTENT)
         rendered = template.render(
             job_name="test-mig",
             namespace="default",
@@ -172,6 +172,137 @@ class TestJinjaTemplateRendering(unittest.TestCase):
         self.assertIn("nvidia.com/mig-1g.5gb: 2", rendered)
         self.assertEqual(rendered.count("nvidia.com/mig-1g.5gb: 2"), 2)
         self.assertIn('nvidia.com/mig.config.state: "success"', rendered)
+
+
+class TestReplicaCount(unittest.TestCase):
+    """Test replica_count / node_count behavior."""
+
+    def test_replica_count_with_resources(self):
+        """replica_count can be combined with explicit resource fields through the full pipeline."""
+        config = PyTorchJobConfig(
+            job_name="test-replica-resources",
+            image="pytorch:latest",
+            replica_count=4,
+            accelerators=2,
+            instance_type="ml.p4d.24xlarge",
+        )
+        job = config.to_domain()
+        job_with_resources = HyperPodPytorchJob.allocate_quotas_if_applicable(job)
+        self.assertEqual(job_with_resources.replicaSpecs[0].replicas, 4)
+        container = job_with_resources.replicaSpecs[0].template.spec.containers[0]
+        self.assertEqual(int(container.resources.requests["nvidia.com/gpu"]), 2)
+
+    def test_replica_count_without_resources_auto_calculates(self):
+        """replica_count without resources auto-calculates from instance type."""
+        config = PyTorchJobConfig(
+            job_name="test-replica-auto",
+            image="pytorch:latest",
+            replica_count=4,
+            instance_type="ml.p4d.24xlarge",
+        )
+        job = config.to_domain()
+        job_with_resources = HyperPodPytorchJob.allocate_quotas_if_applicable(job)
+        container = job_with_resources.replicaSpecs[0].template.spec.containers[0]
+        self.assertIn("nvidia.com/gpu", container.resources.requests)
+
+    def test_node_count_with_resources_rejected(self):
+        """node_count cannot be combined with resource fields."""
+        with self.assertRaises(ValueError, msg="node_count cannot be combined with resource fields"):
+            PyTorchJobConfig(
+                job_name="test-node-resources",
+                image="pytorch:latest",
+                node_count=4,
+                accelerators=2,
+                instance_type="ml.p4d.24xlarge",
+            )
+
+    def test_node_count_with_limit_fields_rejected(self):
+        """node_count cannot be combined with limit-only resource fields either."""
+        with self.assertRaises(ValueError, msg="node_count cannot be combined with resource fields"):
+            PyTorchJobConfig(
+                job_name="test-node-limits",
+                image="pytorch:latest",
+                node_count=4,
+                accelerators_limit=2,
+                instance_type="ml.p4d.24xlarge",
+            )
+
+    def test_replica_count_and_node_count_mutually_exclusive(self):
+        """replica_count and node_count cannot be specified together."""
+        with self.assertRaises(ValueError, msg="Only one of 'replica_count' or 'node_count'"):
+            PyTorchJobConfig(
+                job_name="test-both",
+                image="pytorch:latest",
+                replica_count=4,
+                node_count=4,
+                instance_type="ml.p4d.24xlarge",
+            )
+
+    def test_max_replica_count_and_max_node_count_mutually_exclusive(self):
+        """max_replica_count and max_node_count cannot be specified together."""
+        with self.assertRaises(ValueError, msg="Only one of 'max_replica_count' or 'max_node_count'"):
+            PyTorchJobConfig(
+                job_name="test-both-max",
+                image="pytorch:latest",
+                replica_count=2,
+                max_replica_count=8,
+                max_node_count=8,
+                instance_type="ml.p4d.24xlarge",
+            )
+
+    def test_node_count_still_works(self):
+        """node_count without resources still works (backward compatible)."""
+        config = PyTorchJobConfig(
+            job_name="test-node-compat",
+            image="pytorch:latest",
+            node_count=4,
+            instance_type="ml.p4d.24xlarge",
+        )
+        job = config.to_domain()
+        self.assertEqual(job.replicaSpecs[0].replicas, 4)
+
+    def test_max_replica_count_in_elastic_policy(self):
+        """max_replica_count sets max_replicas in elastic policy."""
+        config = PyTorchJobConfig(
+            job_name="test-elastic",
+            image="pytorch:latest",
+            replica_count=2,
+            max_replica_count=8,
+            elastic_replica_increment_step=2,
+            instance_type="ml.p4d.24xlarge",
+        )
+        job = config.to_domain()
+        self.assertEqual(job.elasticPolicy.maxReplicas, 8)
+        self.assertEqual(job.elasticPolicy.minReplicas, 2)
+
+    def test_replica_count_with_max_node_count(self):
+        """replica_count can be mixed with max_node_count (old + new params)."""
+        config = PyTorchJobConfig(
+            job_name="test-mixed",
+            image="pytorch:latest",
+            replica_count=2,
+            max_node_count=8,
+            elastic_replica_increment_step=2,
+            instance_type="ml.p4d.24xlarge",
+        )
+        job = config.to_domain()
+        self.assertEqual(job.replicaSpecs[0].replicas, 2)
+        self.assertEqual(job.elasticPolicy.maxReplicas, 8)
+
+    def test_replica_count_renders_in_template(self):
+        """replica_count renders correctly in the Jinja template."""
+        template = JinjaTemplate(TEMPLATE_CONTENT)
+        rendered = template.render(
+            job_name="test-replica",
+            namespace="default",
+            image="pytorch:latest",
+            replica_count=4,
+            accelerators=2,
+            accelerators_limit=2,
+            instance_type="ml.p4d.24xlarge",
+        )
+        self.assertIn("replicas: 4", rendered)
+        self.assertIn("nvidia.com/gpu: 2", rendered)
 
 
 class TestDeepHealthCheckNodeSelector(unittest.TestCase):


### PR DESCRIPTION
## What's changing and why?

Closes #383

`node_count` is overloaded: it sets both the number of job replicas and triggers full-node resource allocation. This means users who want multiple replicas with granular resource requests (e.g. 4 replicas each with 2 GPUs) have no way to express that.

This PR introduces `replica_count` to decouple replica specification from resource allocation, and deprecates `node_count`. The naming aligns with the inference CLI, which already uses `replica_count` / `max_replica_count` / `min_replica_count`.

### New parameters

- `replica_count` - number of job replicas (pods). Can be combined with resource fields.
- `max_replica_count` - maximum replicas for elastic training.

### Deprecated parameters (kept as aliases)

- `node_count` - alias for `replica_count` that also triggers full-node resource allocation from instance constants (preserves existing behavior).
- `max_node_count` - alias for `max_replica_count`.

Deprecated fields are marked with `"deprecated": true` in the schema and `[DEPRECATED]` in descriptions. `hyp init` hides deprecated fields from generated config templates. CLI `--help` shows the deprecation tag.

### Additional cleanup

- Moved the `node_count` + resources mutual exclusivity check from `_is_valid()` to the model validator, with an actionable error message guiding users to `replica_count`.
- Standardized error messages: field names in snake_case, user values quoted, specific capacity numbers included.

## Before/After UX

**Before (impossible):**
```yaml
node_count: 4
accelerators: 2
instance_type: ml.p4d.24xlarge
# Error: Either node-count OR a combination of accelerators, vcpu, memory-in-gib must be specified
```

**After:**
```yaml
replica_count: 4
accelerators: 2
instance_type: ml.p4d.24xlarge
# Works: 4 replicas, each with 2 GPUs
```

**Existing behavior preserved:**
```yaml
node_count: 4
instance_type: ml.p4d.24xlarge
# Still works: 4 replicas, each with all resources of a p4d
```

**Improved error message:**
```yaml
node_count: 4
accelerators: 2
instance_type: ml.p4d.24xlarge
# Error: node_count cannot be combined with resource fields (accelerators, vcpu, memory).
#        Use replica_count instead to specify replicas with granular resources.
```

## How was this change tested?

- All unit tests pass
- Verified `hyp init` hides deprecated fields
- Verified `--replica-count` and `--max-replica-count` CLI flags are auto-generated

## Are unit tests added?

Yes. `TestReplicaCount` class with 10 tests:
- replica_count + resources (full pipeline)
- replica_count without resources (auto-calculates)
- node_count + resources rejected
- node_count + limit fields rejected
- replica_count + node_count mutually exclusive
- max_replica_count + max_node_count mutually exclusive
- node_count backward compatibility
- max_replica_count in elastic policy
- replica_count + max_node_count (mixed old/new)
- replica_count template rendering

## Are integration tests added?

Updated existing integ test for new error message format.

## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [ ] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only