### PR TITLE
Fix namespaced-role-and-bindings helm chart bugs

### DIFF
--- a/helm_chart/HyperPodHelmChart/charts/namespaced-role-and-bindings/templates/namespace-level-role.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/namespaced-role-and-bindings/templates/namespace-level-role.yaml
@@ -34,7 +34,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: kubeflow
+  namespace: {{ .Values.namespace }}
   name: {{ .Values.roleName }}-binding
 subjects:
 - kind: Group

--- a/helm_chart/HyperPodHelmChart/values.yaml
+++ b/helm_chart/HyperPodHelmChart/values.yaml
@@ -140,7 +140,7 @@ cluster-role-and-bindings:
   enabled: false
 
 namespaced-role-and-bindings:
-  enable: false
+  enabled: false
 
 team-role-and-bindings:
   enabled: false


### PR DESCRIPTION
## What's changing and why?

Fixing two bugs in the `namespaced-role-and-bindings` subchart:

1. `Chart.yaml` defines the condition as `namespaced-role-and-bindings.enabled`, but `values.yaml` uses `enable` (missing the trailing `d`). The condition never matches, so the subchart cannot be disabled via values.

2. The RoleBinding template hardcodes `namespace: kubeflow` instead of using `{{ .Values.namespace }}`. The Role on line 4 is correctly templated, but the RoleBinding on line 37 is not. If a user configures a different namespace, the RoleBinding is created in `kubeflow` while the Role is created in the configured namespace.

## Before/After UX

**Fix 1:**
```yaml
# values.yaml before
namespaced-role-and-bindings:
  enable: false   # has no effect, subchart always installs

# values.yaml after
namespaced-role-and-bindings:
  enabled: false  # correctly disables the subchart
```

**Fix 2:**
```yaml
# before
metadata:
  namespace: kubeflow  # always kubeflow regardless of config

# after
metadata:
  namespace: {{ .Values.namespace }}  # respects configured namespace
```

## How was this change tested?

- Verified `Chart.yaml` line 78 uses `namespaced-role-and-bindings.enabled` as the condition
- Confirmed all other subcharts in `values.yaml` use `enabled` (this was the only outlier)
- Confirmed the Role on line 4 already uses `{{ .Values.namespace }}`

## Are unit tests added?

N/A (Helm chart fix)

## Are integration tests added?

N/A

## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [ ] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only