### PR TITLE
Add jobsource telemetry to HPCLI release_v2 branch

### DIFF
--- a/src/hyperpod_cli/telemetry/telemetry_logging.py
+++ b/src/hyperpod_cli/telemetry/telemetry_logging.py
@@ -310,6 +310,9 @@ def _send_telemetry_request(
         logger.warning("SageMaker Python SDK telemetry not emitted!")
 
 
+V2_HPCLI_JOB_SOURCE = "v2HPCLI"
+
+
 def _hyperpod_telemetry_emitter(feature: str, func_name: str):
     def decorator(func):
         @functools.wraps(func)
@@ -319,6 +322,7 @@ def _hyperpod_telemetry_emitter(feature: str, func_name: str):
                 f"&x-sdkVersion={SDK_VERSION}"
                 f"&x-env={PYTHON_VERSION}"
                 f"&x-sys={OS_NAME_VERSION}"
+                f"&x-jobsource={V2_HPCLI_JOB_SOURCE}"
             )
             
             # Add comprehensive telemetry data for all functions


### PR DESCRIPTION
## What's changing and why?
<!-- Describe what you're changing and the motivation behind it -->
We add the `jobsource` field to the telemetry emitted by the HPCLI

## Before/After UX
<!-- Show the user experience before and after your changes -->
**Before:**
Same

**After:**
Same

## How was this change tested?
<!-- Describe your testing approach -->
- Local testing with both manual override to log the telemetry URL, as well as `mitmproxy`
- Testing with internal forks using the same code change 

## Are unit tests added?
No

## Are integration tests added?
No

## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [ ] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only