### PR TITLE
[Inference Operator] Update CRDs and Helm chart to v3.1

### DIFF
--- a/helm_chart/HyperPodHelmChart/charts/inference-operator/Chart.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/inference-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.2.0
 
 # This is the version number of the application being deployed. Keep this aligned 
 # with operator image MAJOR.MINOR version.

--- a/helm_chart/HyperPodHelmChart/charts/inference-operator/config/crd/inference.sagemaker.aws.amazon.com_inferenceendpointconfigs.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/inference-operator/config/crd/inference.sagemaker.aws.amazon.com_inferenceendpointconfigs.yaml
@@ -270,7 +270,7 @@ spec:
                         type: string
                       serverAddress:
                         description: Server address for AMP workspace
-                        pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+\/[a-zA-Z0-9-]+$|^$
+                        pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+$|^$
                         type: string
                       targetValue:
                         description: Target metric value for scaling
@@ -315,7 +315,7 @@ spec:
                           type: string
                         serverAddress:
                           description: Server address for AMP workspace
-                          pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+\/[a-zA-Z0-9-]+$|^$
+                          pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+$|^$
                           type: string
                         targetValue:
                           description: Target metric value for scaling
@@ -342,6 +342,211 @@ spec:
                     format: int32
                     minimum: 0
                     type: integer
+                type: object
+              dataCapture:
+                description: Configuration for data capture across multiple tiers
+                  (SageMaker, LoadBalancer, Model Pod)
+                properties:
+                  loadBalancer:
+                    description: Configuration for LoadBalancer level data capture
+                      (Tier 2)
+                    properties:
+                      enabled:
+                        description: Enable or disable load balancer access logs
+                        type: boolean
+                    required:
+                    - enabled
+                    type: object
+                  modelPod:
+                    description: Configuration for Model Pod level data capture (Tier
+                      3)
+                    properties:
+                      bufferConfig:
+                        description: Configuration for buffering and flushing captured
+                          data
+                        properties:
+                          batchSize:
+                            default: 10
+                            description: Number of records to batch before writing
+                              to S3
+                            format: int32
+                            maximum: 1000
+                            minimum: 1
+                            type: integer
+                          flushIntervalSeconds:
+                            default: 60
+                            description: Flush interval in seconds
+                            format: int32
+                            maximum: 300
+                            minimum: 10
+                            type: integer
+                        type: object
+                      captureContentTypeHeader:
+                        description: Configuration for how to treat different content
+                          type headers during capture
+                        properties:
+                          csvContentTypes:
+                            description: |-
+                              List of content type headers to treat as CSV
+                              Each item must be 1-256 characters and match pattern: [a-zA-Z0-9](-*[a-zA-Z0-9])*/[a-zA-Z0-9](-*[a-zA-Z0-9.])*
+                              Example: text/csv, application/csv
+                            items:
+                              type: string
+                            maxItems: 10
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                          jsonContentTypes:
+                            description: |-
+                              List of content type headers to treat as JSON
+                              Each item must be 1-256 characters and match pattern: [a-zA-Z0-9](-*[a-zA-Z0-9])*/[a-zA-Z0-9](-*[a-zA-Z0-9.])*
+                              Example: application/json, application/jsonlines
+                            items:
+                              type: string
+                            maxItems: 10
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                        type: object
+                      captureOptions:
+                        description: Capture options (Input, Output, or both). Defaults
+                          to [Input, Output] when enabled.
+                        items:
+                          description: CaptureOption defines what data to capture
+                            (input, output, or both).
+                          properties:
+                            captureMode:
+                              description: 'Capture mode: Input or Output'
+                              enum:
+                              - Input
+                              - Output
+                              type: string
+                          required:
+                          - captureMode
+                          type: object
+                        maxItems: 32
+                        minItems: 1
+                        type: array
+                      enabled:
+                        description: Enable or disable model pod data capture
+                        type: boolean
+                      initialSamplingPercentage:
+                        description: Percentage of requests to capture (0-100). Defaults
+                          to 100 when enabled.
+                        format: int32
+                        maximum: 100
+                        minimum: 0
+                        type: integer
+                      kmsKeyId:
+                        description: Optional KMS key ID, ARN, alias name, or alias
+                          ARN for encrypting captured data
+                        maxLength: 2048
+                        pattern: ^[a-zA-Z0-9:/_-]*$
+                        type: string
+                      payloadConfig:
+                        description: Configuration for payload size limits
+                        properties:
+                          maxPayloadSizeKB:
+                            default: 0
+                            description: Maximum payload size in KB to capture. 0
+                              means no limit (capture full payload).
+                            format: int32
+                            maximum: 10240
+                            minimum: 0
+                            type: integer
+                        type: object
+                    required:
+                    - enabled
+                    type: object
+                  s3Uri:
+                    description: |-
+                      Common S3 URI for all data capture tiers. Each tier will write to a specific prefix within this bucket.
+                      Must use s3:// protocol (required by ALB access logs).
+                      If not provided, the TLS certificate bucket will be used for data capture storage.
+                    maxLength: 512
+                    pattern: ^s3://([^/]+)(/[^,=]*)?$
+                    type: string
+                  sagemakerEndpoint:
+                    description: Configuration for SageMaker Endpoint level data capture
+                      (Tier 1)
+                    properties:
+                      captureContentTypeHeader:
+                        description: Configuration for how to treat different content
+                          type headers during capture
+                        properties:
+                          csvContentTypes:
+                            description: |-
+                              List of content type headers to treat as CSV
+                              Each item must be 1-256 characters and match pattern: [a-zA-Z0-9](-*[a-zA-Z0-9])*/[a-zA-Z0-9](-*[a-zA-Z0-9.])*
+                              Example: text/csv, application/csv
+                            items:
+                              type: string
+                            maxItems: 10
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                          jsonContentTypes:
+                            description: |-
+                              List of content type headers to treat as JSON
+                              Each item must be 1-256 characters and match pattern: [a-zA-Z0-9](-*[a-zA-Z0-9])*/[a-zA-Z0-9](-*[a-zA-Z0-9.])*
+                              Example: application/json, application/jsonlines
+                            items:
+                              type: string
+                            maxItems: 10
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                        type: object
+                      captureOptions:
+                        description: Capture options (Input, Output, or both). Defaults
+                          to [Input, Output] when enabled.
+                        items:
+                          description: CaptureOption defines what data to capture
+                            (input, output, or both).
+                          properties:
+                            captureMode:
+                              description: 'Capture mode: Input or Output'
+                              enum:
+                              - Input
+                              - Output
+                              type: string
+                          required:
+                          - captureMode
+                          type: object
+                        maxItems: 32
+                        minItems: 1
+                        type: array
+                      enabled:
+                        description: Enable or disable SageMaker endpoint data capture
+                        type: boolean
+                      initialSamplingPercentage:
+                        description: Percentage of requests to capture (0-100). Defaults
+                          to 100 when enabled.
+                        format: int32
+                        maximum: 100
+                        minimum: 0
+                        type: integer
+                      kmsKeyId:
+                        description: Optional KMS key ID, ARN, alias name, or alias
+                          ARN for encrypting captured data
+                        maxLength: 2048
+                        pattern: ^[a-zA-Z0-9:/_-]*$
+                        type: string
+                    required:
+                    - enabled
+                    type: object
+                type: object
+              dnsConfig:
+                description: DNS automation configuration for Route53. Requires tlsConfig.customCertificateConfig
+                  to be set.
+                properties:
+                  hostedZoneId:
+                    description: Route53 Hosted Zone ID where the DNS record will
+                      be created.
+                    pattern: ^Z[A-Z0-9]+$
+                    type: string
+                required:
+                - hostedZoneId
                 type: object
               endpointName:
                 description: |-
@@ -589,7 +794,7 @@ spec:
                             type: string
                           serverAddress:
                             description: Server address for AMP workspace
-                            pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+\/[a-zA-Z0-9-]+$|^$
+                            pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+$|^$
                             type: string
                           targetValue:
                             description: Target metric value for scaling
@@ -636,7 +841,7 @@ spec:
                               type: string
                             serverAddress:
                               description: Server address for AMP workspace
-                              pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+\/[a-zA-Z0-9-]+$|^$
+                              pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+$|^$
                               type: string
                             targetValue:
                               description: Target metric value for scaling
@@ -2227,6 +2432,14 @@ spec:
                     description: |-
                       Name of the scheduler to use for pod scheduling.
                       If not specified, the default Kubernetes scheduler will be used.
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  serviceAccountName:
+                    description: |-
+                      Name of the Kubernetes ServiceAccount to use for the inference pod.
+                      If not specified, the namespace's default service account will be used.
+                      This is useful for providing AWS credentials via IRSA to init containers or the worker.
                     maxLength: 253
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
@@ -4249,6 +4462,50 @@ spec:
                     required:
                     - fileSystemId
                     type: object
+                  huggingFaceModel:
+                    description: HuggingFace model configuration. Required when modelSourceType
+                      is "huggingface".
+                    properties:
+                      commitSHA:
+                        description: |-
+                          Git commit SHA for the model revision. Must be a full 40-character lowercase hex SHA.
+                          If not provided, the operator defaults to "main" branch.
+                        pattern: ^[0-9a-f]{40}$
+                        type: string
+                      modelId:
+                        description: HuggingFace Hub model identifier in org/model
+                          format (e.g. "meta-llama/Llama-3.1-8B-Instruct").
+                        pattern: ^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$
+                        type: string
+                      tokenSecretRef:
+                        description: |-
+                          Reference to a Kubernetes Secret containing the HuggingFace API token.
+                          The token is injected as the HF_TOKEN environment variable into the InitContainer only.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - modelId
+                    type: object
                   modelLocation:
                     description: Specific location where the model data exists
                     type: string
@@ -4256,6 +4513,8 @@ spec:
                     enum:
                     - fsx
                     - s3
+                    - huggingface
+                    - kubernetesVolume
                     type: string
                   prefetchEnabled:
                     default: false
@@ -5492,6 +5751,44 @@ spec:
                 - lastUpdated
                 - name
                 type: object
+              dnsStatus:
+                description: Status of the operator-managed Route53 DNS record
+                properties:
+                  dnsHealth:
+                    description: 'DNS resolution status: Active, Pending, or Error.'
+                    enum:
+                    - Active
+                    - Pending
+                    - Error
+                    type: string
+                  hostedZoneId:
+                    description: Route53 hosted zone ID.
+                    type: string
+                  lastTransitionTime:
+                    description: When the status last transitioned, used for propagation
+                      timeout.
+                    format: date-time
+                    type: string
+                  managedByOperator:
+                    description: Whether the operator manages this DNS record.
+                    type: boolean
+                  message:
+                    description: Human-readable status or error message.
+                    type: string
+                  previousHostedZoneId:
+                    description: Previous hosted zone ID, retained during domain/zone
+                      changes until cleanup completes.
+                    type: string
+                  previousRecordName:
+                    description: Previous record name, retained during domain/zone
+                      changes until cleanup completes.
+                    type: string
+                  recordName:
+                    description: Route53 record name.
+                    type: string
+                required:
+                - managedByOperator
+                type: object
               endpoints:
                 description: EndpointStatus contains the status of SageMaker endpoints
                 properties:
@@ -5801,7 +6098,7 @@ spec:
                         type: string
                       serverAddress:
                         description: Server address for AMP workspace
-                        pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+\/[a-zA-Z0-9-]+$|^$
+                        pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+$|^$
                         type: string
                       targetValue:
                         description: Target metric value for scaling

--- a/helm_chart/HyperPodHelmChart/charts/inference-operator/config/crd/inference.sagemaker.aws.amazon.com_jumpstartmodels.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/inference-operator/config/crd/inference.sagemaker.aws.amazon.com_jumpstartmodels.yaml
@@ -262,7 +262,7 @@ spec:
                         type: string
                       serverAddress:
                         description: Server address for AMP workspace
-                        pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+\/[a-zA-Z0-9-]+$|^$
+                        pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+$|^$
                         type: string
                       targetValue:
                         description: Target metric value for scaling
@@ -307,7 +307,7 @@ spec:
                           type: string
                         serverAddress:
                           description: Server address for AMP workspace
-                          pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+\/[a-zA-Z0-9-]+$|^$
+                          pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+$|^$
                           type: string
                         targetValue:
                           description: Target metric value for scaling
@@ -334,6 +334,211 @@ spec:
                     format: int32
                     minimum: 0
                     type: integer
+                type: object
+              dataCapture:
+                description: Configuration for data capture across multiple tiers
+                  (SageMaker, LoadBalancer, Model Pod)
+                properties:
+                  loadBalancer:
+                    description: Configuration for LoadBalancer level data capture
+                      (Tier 2)
+                    properties:
+                      enabled:
+                        description: Enable or disable load balancer access logs
+                        type: boolean
+                    required:
+                    - enabled
+                    type: object
+                  modelPod:
+                    description: Configuration for Model Pod level data capture (Tier
+                      3)
+                    properties:
+                      bufferConfig:
+                        description: Configuration for buffering and flushing captured
+                          data
+                        properties:
+                          batchSize:
+                            default: 10
+                            description: Number of records to batch before writing
+                              to S3
+                            format: int32
+                            maximum: 1000
+                            minimum: 1
+                            type: integer
+                          flushIntervalSeconds:
+                            default: 60
+                            description: Flush interval in seconds
+                            format: int32
+                            maximum: 300
+                            minimum: 10
+                            type: integer
+                        type: object
+                      captureContentTypeHeader:
+                        description: Configuration for how to treat different content
+                          type headers during capture
+                        properties:
+                          csvContentTypes:
+                            description: |-
+                              List of content type headers to treat as CSV
+                              Each item must be 1-256 characters and match pattern: [a-zA-Z0-9](-*[a-zA-Z0-9])*/[a-zA-Z0-9](-*[a-zA-Z0-9.])*
+                              Example: text/csv, application/csv
+                            items:
+                              type: string
+                            maxItems: 10
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                          jsonContentTypes:
+                            description: |-
+                              List of content type headers to treat as JSON
+                              Each item must be 1-256 characters and match pattern: [a-zA-Z0-9](-*[a-zA-Z0-9])*/[a-zA-Z0-9](-*[a-zA-Z0-9.])*
+                              Example: application/json, application/jsonlines
+                            items:
+                              type: string
+                            maxItems: 10
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                        type: object
+                      captureOptions:
+                        description: Capture options (Input, Output, or both). Defaults
+                          to [Input, Output] when enabled.
+                        items:
+                          description: CaptureOption defines what data to capture
+                            (input, output, or both).
+                          properties:
+                            captureMode:
+                              description: 'Capture mode: Input or Output'
+                              enum:
+                              - Input
+                              - Output
+                              type: string
+                          required:
+                          - captureMode
+                          type: object
+                        maxItems: 32
+                        minItems: 1
+                        type: array
+                      enabled:
+                        description: Enable or disable model pod data capture
+                        type: boolean
+                      initialSamplingPercentage:
+                        description: Percentage of requests to capture (0-100). Defaults
+                          to 100 when enabled.
+                        format: int32
+                        maximum: 100
+                        minimum: 0
+                        type: integer
+                      kmsKeyId:
+                        description: Optional KMS key ID, ARN, alias name, or alias
+                          ARN for encrypting captured data
+                        maxLength: 2048
+                        pattern: ^[a-zA-Z0-9:/_-]*$
+                        type: string
+                      payloadConfig:
+                        description: Configuration for payload size limits
+                        properties:
+                          maxPayloadSizeKB:
+                            default: 0
+                            description: Maximum payload size in KB to capture. 0
+                              means no limit (capture full payload).
+                            format: int32
+                            maximum: 10240
+                            minimum: 0
+                            type: integer
+                        type: object
+                    required:
+                    - enabled
+                    type: object
+                  s3Uri:
+                    description: |-
+                      Common S3 URI for all data capture tiers. Each tier will write to a specific prefix within this bucket.
+                      Must use s3:// protocol (required by ALB access logs).
+                      If not provided, the TLS certificate bucket will be used for data capture storage.
+                    maxLength: 512
+                    pattern: ^s3://([^/]+)(/[^,=]*)?$
+                    type: string
+                  sagemakerEndpoint:
+                    description: Configuration for SageMaker Endpoint level data capture
+                      (Tier 1)
+                    properties:
+                      captureContentTypeHeader:
+                        description: Configuration for how to treat different content
+                          type headers during capture
+                        properties:
+                          csvContentTypes:
+                            description: |-
+                              List of content type headers to treat as CSV
+                              Each item must be 1-256 characters and match pattern: [a-zA-Z0-9](-*[a-zA-Z0-9])*/[a-zA-Z0-9](-*[a-zA-Z0-9.])*
+                              Example: text/csv, application/csv
+                            items:
+                              type: string
+                            maxItems: 10
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                          jsonContentTypes:
+                            description: |-
+                              List of content type headers to treat as JSON
+                              Each item must be 1-256 characters and match pattern: [a-zA-Z0-9](-*[a-zA-Z0-9])*/[a-zA-Z0-9](-*[a-zA-Z0-9.])*
+                              Example: application/json, application/jsonlines
+                            items:
+                              type: string
+                            maxItems: 10
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                        type: object
+                      captureOptions:
+                        description: Capture options (Input, Output, or both). Defaults
+                          to [Input, Output] when enabled.
+                        items:
+                          description: CaptureOption defines what data to capture
+                            (input, output, or both).
+                          properties:
+                            captureMode:
+                              description: 'Capture mode: Input or Output'
+                              enum:
+                              - Input
+                              - Output
+                              type: string
+                          required:
+                          - captureMode
+                          type: object
+                        maxItems: 32
+                        minItems: 1
+                        type: array
+                      enabled:
+                        description: Enable or disable SageMaker endpoint data capture
+                        type: boolean
+                      initialSamplingPercentage:
+                        description: Percentage of requests to capture (0-100). Defaults
+                          to 100 when enabled.
+                        format: int32
+                        maximum: 100
+                        minimum: 0
+                        type: integer
+                      kmsKeyId:
+                        description: Optional KMS key ID, ARN, alias name, or alias
+                          ARN for encrypting captured data
+                        maxLength: 2048
+                        pattern: ^[a-zA-Z0-9:/_-]*$
+                        type: string
+                    required:
+                    - enabled
+                    type: object
+                type: object
+              dnsConfig:
+                description: DNS automation configuration for Route53. Requires tlsConfig.customCertificateConfig
+                  to be set.
+                properties:
+                  hostedZoneId:
+                    description: Route53 Hosted Zone ID where the DNS record will
+                      be created.
+                    pattern: ^Z[A-Z0-9]+$
+                    type: string
+                required:
+                - hostedZoneId
                 type: object
               environmentVariables:
                 description: Additional environment variables to be passed to the
@@ -576,7 +781,7 @@ spec:
                             type: string
                           serverAddress:
                             description: Server address for AMP workspace
-                            pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+\/[a-zA-Z0-9-]+$|^$
+                            pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+$|^$
                             type: string
                           targetValue:
                             description: Target metric value for scaling
@@ -623,7 +828,7 @@ spec:
                               type: string
                             serverAddress:
                               description: Server address for AMP workspace
-                              pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+\/[a-zA-Z0-9-]+$|^$
+                              pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+$|^$
                               type: string
                             targetValue:
                               description: Target metric value for scaling
@@ -1031,7 +1236,7 @@ spec:
                           Total number of terminating pods targeted by this deployment. Terminating pods have a non-null
                           .metadata.deletionTimestamp and have not yet reached the Failed or Succeeded .status.phase.
 
-                          This is an alpha field. Enable DeploymentReplicaSetTerminatingReplicas to be able to use this field.
+                          This is a beta field and requires enabling DeploymentReplicaSetTerminatingReplicas feature (enabled by default).
                         format: int32
                         type: integer
                       unavailableReplicas:
@@ -1050,6 +1255,44 @@ spec:
                 required:
                 - lastUpdated
                 - name
+                type: object
+              dnsStatus:
+                description: Status of the operator-managed Route53 DNS record
+                properties:
+                  dnsHealth:
+                    description: 'DNS resolution status: Active, Pending, or Error.'
+                    enum:
+                    - Active
+                    - Pending
+                    - Error
+                    type: string
+                  hostedZoneId:
+                    description: Route53 hosted zone ID.
+                    type: string
+                  lastTransitionTime:
+                    description: When the status last transitioned, used for propagation
+                      timeout.
+                    format: date-time
+                    type: string
+                  managedByOperator:
+                    description: Whether the operator manages this DNS record.
+                    type: boolean
+                  message:
+                    description: Human-readable status or error message.
+                    type: string
+                  previousHostedZoneId:
+                    description: Previous hosted zone ID, retained during domain/zone
+                      changes until cleanup completes.
+                    type: string
+                  previousRecordName:
+                    description: Previous record name, retained during domain/zone
+                      changes until cleanup completes.
+                    type: string
+                  recordName:
+                    description: Route53 record name.
+                    type: string
+                required:
+                - managedByOperator
                 type: object
               endpoints:
                 description: EndpointStatus contains the status of SageMaker endpoints
@@ -1352,7 +1595,7 @@ spec:
                         type: string
                       serverAddress:
                         description: Server address for AMP workspace
-                        pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+\/[a-zA-Z0-9-]+$|^$
+                        pattern: ^https:\/\/aps-workspaces\.[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.amazonaws\.com\/workspaces\/ws-[a-zA-Z0-9-]+$|^$
                         type: string
                       targetValue:
                         description: Target metric value for scaling
@@ -1701,7 +1944,7 @@ spec:
                           Total number of terminating pods targeted by this deployment. Terminating pods have a non-null
                           .metadata.deletionTimestamp and have not yet reached the Failed or Succeeded .status.phase.
 
-                          This is an alpha field. Enable DeploymentReplicaSetTerminatingReplicas to be able to use this field.
+                          This is a beta field and requires enabling DeploymentReplicaSetTerminatingReplicas feature (enabled by default).
                         format: int32
                         type: integer
                       unavailableReplicas:

--- a/helm_chart/HyperPodHelmChart/charts/inference-operator/config/crd/inference.sagemaker.aws.amazon.com_sagemakerendpointregistrations.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/inference-operator/config/crd/inference.sagemaker.aws.amazon.com_sagemakerendpointregistrations.yaml
@@ -114,6 +114,95 @@ spec:
                 description: REST API Gateway identifier that proxies requests to
                   the HyperPod endpoint (via NLB/ALB)
                 type: string
+              sageMakerEndpointDataCaptureConfig:
+                description: Configuration for SageMaker endpoint data capture
+                properties:
+                  captureContentTypeHeader:
+                    description: Configuration for how to treat different content
+                      type headers during capture
+                    properties:
+                      csvContentTypes:
+                        description: |-
+                          List of content type headers to treat as CSV
+                          Each item must be 1-256 characters and match pattern: [a-zA-Z0-9](-*[a-zA-Z0-9])*/[a-zA-Z0-9](-*[a-zA-Z0-9.])*
+                          Example: text/csv, application/csv
+                        items:
+                          type: string
+                        maxItems: 10
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-type: set
+                      jsonContentTypes:
+                        description: |-
+                          List of content type headers to treat as JSON
+                          Each item must be 1-256 characters and match pattern: [a-zA-Z0-9](-*[a-zA-Z0-9])*/[a-zA-Z0-9](-*[a-zA-Z0-9.])*
+                          Example: application/json, application/jsonlines
+                        items:
+                          type: string
+                        maxItems: 10
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  captureOptions:
+                    description: Capture options specifying what to capture (Input,
+                      Output, or both)
+                    items:
+                      description: CaptureOption defines what data to capture (input,
+                        output, or both).
+                      properties:
+                        captureMode:
+                          description: 'Capture mode: Input or Output'
+                          enum:
+                          - Input
+                          - Output
+                          type: string
+                      required:
+                      - captureMode
+                      type: object
+                    maxItems: 32
+                    minItems: 1
+                    type: array
+                  destinationS3Uri:
+                    description: S3 URI where captured data will be stored
+                    maxLength: 512
+                    pattern: ^s3://([^/]+)(/.*)?$
+                    type: string
+                  enabled:
+                    description: Enable or disable SageMaker endpoint data capture
+                    type: boolean
+                  initialSamplingPercentage:
+                    description: Percentage of requests to capture (0-100)
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
+                  kmsKeyId:
+                    description: Optional KMS key ID, ARN, alias name, or alias ARN
+                      for encrypting captured data
+                    maxLength: 2048
+                    pattern: ^[a-zA-Z0-9:/_-]*$
+                    type: string
+                required:
+                - captureOptions
+                - destinationS3Uri
+                - enabled
+                - initialSamplingPercentage
+                type: object
+              tags:
+                description: User-defined tags to propagate to SageMaker resources
+                  (Model, EndpointConfig, Endpoint)
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
               tlsConfig:
                 properties:
                   tlsCertificateOutputS3Bucket:
@@ -352,6 +441,20 @@ spec:
                 description: REST API Gateway identifier that proxies requests to
                   the HyperPod endpoint (via NLB/ALB)
                 type: string
+              tags:
+                description: User-defined tags to propagate to SageMaker resources
+                  (Model, EndpointConfig, Endpoint)
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
               tlsConfig:
                 properties:
                   tlsCertificateOutputS3Bucket:

--- a/helm_chart/HyperPodHelmChart/charts/inference-operator/values.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/inference-operator/values.yaml
@@ -27,6 +27,9 @@ image:
   tag: v3.1
   pullPolicy: Always
   repository:
+  initContainer:
+    repository: hyperpod-inference-operator-init-container
+    tag: v1.0.1
 hyperpodClusterArn:
 executionRoleArn:
 jumpstartGatedModelDownloadRoleArn: ""


### PR DESCRIPTION
## Summary

Update inference operator CRDs and Helm chart to v3.1 (chart version 2.1.0).

Synced from internal AWSCrescendoInferenceOperator repo.

## Changes

### InferenceEndpointConfig & JumpStartModel CRDs
- **Data capture**: 3-tier capture configuration (SageMaker endpoint, LoadBalancer access logs, Model Pod level)
- **DNS automation**: Route53 `dnsConfig` (spec) and `dnsStatus` (status) for automated DNS record management
- **HuggingFace model source**: New `huggingFaceModel` model source type with `modelId`, `commitSHA`, and `tokenSecretRef`
- **Kubernetes volume source**: New `kubernetesVolume` model source type
- **ServiceAccount support**: `serviceAccountName` field for IRSA credentials on inference pods
- **APS workspace URL pattern fix**: Corrected regex pattern for AMP workspace URLs

### SageMakerEndpointRegistration CRD
- **Data capture config**: `sageMakerEndpointDataCaptureConfig` for standalone endpoint registrations
- **User-defined tags**: `tags` field in both spec and status for propagating tags to SageMaker resources

### Chart.yaml
- Minor trailing newline fix

### values.yaml
- Added `initContainer` image configuration (`repository` and `tag`)

## Files Changed
- `helm_chart/HyperPodHelmChart/charts/inference-operator/config/crd/*.yaml` — CRD schema updates
- `helm_chart/HyperPodHelmChart/charts/inference-operator/Chart.yaml` — newline fix
- `helm_chart/HyperPodHelmChart/charts/inference-operator/values.yaml` — init container config

## Validation
- [x] CRD YAML is valid (verified with YAML parser)
- [x] Chart.yaml and values.yaml are valid YAML
- [x] Version numbers are consistent (appVersion=3.1, chart version=2.1.0)
- [x] Unit tests pass (102/102)
- [ ] `helm template` — skipped due to pre-existing missing chart dependencies (not related to this change)

## Reference
- Example PR: https://github.com/aws/sagemaker-hyperpod-cli/pull/402