### PR TITLE
chore: upgrade gpu operator v25.3.4 → v25.10.1

### DIFF
--- a/helm_chart/HyperPodHelmChart/charts/gpu-operator/Chart.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/gpu-operator/Chart.yaml
@@ -25,6 +25,6 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: gpu-operator
-    version: "v25.3.4"
+    version: "v25.10.1"
     repository: "https://helm.ngc.nvidia.com/nvidia"
     condition: gpu-operator.enabled

--- a/helm_chart/HyperPodHelmChart/charts/gpu-operator/values.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/gpu-operator/values.yaml
@@ -2,7 +2,7 @@ gpu-operator:
   enabled: true
   operator:
     image: "mirror-gpu-operator"
-    version: "v25.3.4"
+    version: "v25.10.1"
     tolerations:
       - operator: "Exists"
     initContainer:
@@ -15,21 +15,21 @@ gpu-operator:
     enabled: false
   toolkit:
     image: "container-toolkit"
-    version: "v1.17.9-ubi8"
+    version: "v1.18.1"
   devicePlugin:
     enabled: true
     image: "mirror-k8s-device-plugin"
-    version: "v0.17.4"
+    version: "v0.18.1"
   dcgm:
     enabled: false
   dcgmExporter:
     enabled: false
   gfd:
     image: "mirror-k8s-device-plugin"
-    version: "v0.17.4"
+    version: "v0.18.1"
   migManager:
     image: "k8s-mig-manager"
-    version: "v0.12.3-ubuntu20.04"
+    version: "v0.13.1"
     config:
       create: true
       name: "default-mig-config"
@@ -38,7 +38,7 @@ gpu-operator:
         value: "true"
   validator:
     image: "gpu-operator-validator"
-    version: "v25.3.4"
+    version: "v25.10.1"
   vgpuDeviceManager:
     enabled: false
   vfioManager:


### PR DESCRIPTION
## Problem

Critical CVEs in GPU Operator v25.3.4 container images (built Oct 2025). Blocks OS patching and observability work.

## Fix

Bump all GPU Operator component versions to v25.10.1. Pure version bump — no image name changes, no regional-values changes, no behavioral change.

```
Chart.yaml dependency:  v25.3.4             → v25.10.1
operator:               v25.3.4             → v25.10.1
toolkit:                v1.17.9-ubi8        → v1.18.1
devicePlugin:           v0.17.4             → v0.18.1
gfd:                    v0.17.4             → v0.18.1
migManager:             v0.12.3-ubuntu20.04 → v0.13.1
validator:              v25.3.4             → v25.10.1
```

## Why This Approach

Toolkit behavior is unchanged — `toolkit.enabled` is left absent (defaults to true). The GPU Operator's toolkit DaemonSet coexists safely with the AMI's pre-installed toolkit. Validated on a live HyperPod EKS cluster across 6 test cases including fresh install, parallel toolkit coexistence, upgrade path, HMA compatibility, and full parent chart install.

Disabling the toolkit (`toolkit.enabled: false`) was tested and works for first-time installs, but breaks existing clusters upgrading from v25.3.4 (containerd loses its nvidia runtime config when the toolkit DaemonSet is removed). That's a separate follow-up requiring a migration plan.

## Failure Cases

1. **Existing clusters on v25.3.4:** Safe. Helm release pins version — customers only get v25.10.1 on explicit `helm upgrade`. Toolkit behavior unchanged.
2. **ECR images:** Requires ECR replicator update to mirror v25.10.1 images to regional ECRs before this PR ships. Old v25.3.4 tags remain in ECR for rollback.
3. **Toolkit base image change:** Toolkit moves from `v1.17.9-ubi8` to `v1.18.1` (default variant). HyperPod EKS uses Amazon Linux, not RHEL — default variant is the correct match.

## Scope

Version bumps only. 2 files changed (Chart.yaml + values.yaml). No image name changes, no regional-values changes. Blocked on ECR replicator deploying v25.10.1 images first.

## Checklist

- [x] 6 test cases on live HyperPod EKS cluster
- [x] Toolkit coexistence validated (both AMI v1.19.0 + operator v1.18.1)
- [x] HMA compatibility confirmed (independent, uses kernel log XID matching)
- [x] Backward compatible (existing clusters unaffected)
- [x] ECR replicator deployed with v25.10.1 images (blocker)
