### PR TITLE
feat: Upgrade GPU Operator v25.10.1 → v26.3.1

### DIFF
--- a/helm_chart/HyperPodHelmChart/charts/gpu-operator/Chart.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/gpu-operator/Chart.yaml
@@ -25,6 +25,6 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: gpu-operator
-    version: "v25.10.1"
+    version: "v26.3.1"
     repository: "https://helm.ngc.nvidia.com/nvidia"
     condition: gpu-operator.enabled

--- a/helm_chart/HyperPodHelmChart/charts/gpu-operator/values.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/gpu-operator/values.yaml
@@ -2,7 +2,7 @@ gpu-operator:
   enabled: true
   operator:
     image: "mirror-gpu-operator"
-    version: "v25.10.1"
+    version: "v26.3.1"
     tolerations:
       - operator: "Exists"
     initContainer:
@@ -15,21 +15,21 @@ gpu-operator:
     enabled: false
   toolkit:
     image: "container-toolkit"
-    version: "v1.18.1"
+    version: "v1.19.0"
   devicePlugin:
     enabled: true
     image: "mirror-k8s-device-plugin"
-    version: "v0.18.1"
+    version: "v0.19.0"
   dcgm:
     enabled: false
   dcgmExporter:
     enabled: false
   gfd:
     image: "mirror-k8s-device-plugin"
-    version: "v0.18.1"
+    version: "v0.19.0"
   migManager:
     image: "k8s-mig-manager"
-    version: "v0.13.1"
+    version: "v0.14.0"
     config:
       create: true
       name: "default-mig-config"
@@ -38,7 +38,7 @@ gpu-operator:
         value: "true"
   validator:
     image: "gpu-operator-validator"
-    version: "v25.10.1"
+    version: "v26.3.1"
   vgpuDeviceManager:
     enabled: false
   vfioManager:


### PR DESCRIPTION
CVE remediation — Mirador findings against v25.10.1 base images resolved in v26.3.1. Pure version bump, toolkit stays enabled (parallel coexistence).

- gpu-operator: v25.10.1 → v26.3.1
- device-plugin: v0.18.1 → v0.19.0
- container-toolkit: v1.18.1 → v1.19.0
- mig-manager: v0.13.1 → v0.14.0
- gfd: v0.18.1 → v0.19.0
- validator: v25.10.1 → v26.3.1 (consolidated into gpu-operator image)

SIM: https://t.corp.amazon.com/V2203884559

## What's changing and why?
<!-- Describe what you're changing and the motivation behind it -->


## Before/After UX
<!-- Show the user experience before and after your changes -->
**Before:**


**After:**


## How was this change tested?
<!-- Describe your testing approach -->


## Are unit tests added?


## Are integration tests added?


## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [ ] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only