### PR TITLE
Add node list/get/patch permissions to hyperpod-patching clusterrole

### DIFF
--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-patching/templates/clusterrole.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-patching/templates/clusterrole.yaml
@@ -9,3 +9,6 @@ rules:
   - apiGroups: [""]
     resources: ["pods/eviction"]
     verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list", "get", "patch"]


### PR DESCRIPTION
## Summary
Adds node-level permissions (list, get, patch) to the hyperpod-patching ClusterRole.

## Changes
- Added apiGroups [""] / resources ["nodes"] / verbs ["list", "get", "patch"] to `clusterrole.yaml`

## Testing
- Verified Helm template renders correctly with the new rules.