### PR TITLE
Release new version for Health Monitoring Agent 1.0.1892.0_1.0.424.0 with bug fixes

### DIFF
--- a/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/templates/_helpers.tpl
+++ b/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/templates/_helpers.tpl
@@ -55,7 +55,7 @@ Generate the health monitoring agent image URI based on AWS region
 */}}
 {{- define "health-monitoring-agent.imageUri" -}}
 {{- $region := "" -}}
-{{- $imageTag := .Values.imageTag | default "1.0.1481.0_1.0.392.0" -}}
+{{- $imageTag := .Values.imageTag | default "1.0.1892.0_1.0.424.0" -}}
 
 {{/* Debug: Show image tag selection if debug is enabled */}}
 {{- if .Values.debug -}}

--- a/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/values.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/values.yaml
@@ -25,7 +25,7 @@ imageTag: ""
 
 # Override the health monitoring agent image URI
 # If specified, this will override the automatic region-based URI selection
-# Example: "905418368575.dkr.ecr.us-west-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1481.0_1.0.392.0"
+# Example: "905418368575.dkr.ecr.us-west-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0"
 hmaimage: ""
 
 # Enable debug output for region selection process

--- a/helm_chart/readme.md
+++ b/helm_chart/readme.md
@@ -234,19 +234,19 @@ helm upgrade dependencies helm_chart/HyperPodHelmChart --namespace kube-system
 
 - **Supported Regions and their ECR URIs**:
   ```
-  us-east-1 (US East (N. Virginia)):      767398015722.dkr.ecr.us-east-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1481.0_1.0.392.0
-  us-west-2 (US West (Oregon)):           905418368575.dkr.ecr.us-west-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1481.0_1.0.392.0
-  us-east-2 (US East (Ohio)):             851725546812.dkr.ecr.us-east-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1481.0_1.0.392.0
-  us-west-1 (US West (N. California)):    011528288828.dkr.ecr.us-west-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1481.0_1.0.392.0
-  eu-central-1 (Europe (Frankfurt)):      211125453373.dkr.ecr.eu-central-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1481.0_1.0.392.0
-  eu-north-1 (Europe (Stockholm)):        654654141839.dkr.ecr.eu-north-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1481.0_1.0.392.0
-  eu-west-1 (Europe (Ireland)):           533267293120.dkr.ecr.eu-west-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1481.0_1.0.392.0
-  eu-west-2 (Europe (London)):            011528288831.dkr.ecr.eu-west-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1481.0_1.0.392.0
-  ap-northeast-1 (Asia Pacific (Tokyo)):  533267052152.dkr.ecr.ap-northeast-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1481.0_1.0.392.0
-  ap-south-1 (Asia Pacific (Mumbai)):     011528288864.dkr.ecr.ap-south-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1481.0_1.0.392.0
-  ap-southeast-1 (Asia Pacific (Singapore)): 905418428165.dkr.ecr.ap-southeast-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1481.0_1.0.392.0
-  ap-southeast-2 (Asia Pacific (Sydney)):    851725636348.dkr.ecr.ap-southeast-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1481.0_1.0.392.0
-  sa-east-1 (South America (São Paulo)):     025066253954.dkr.ecr.sa-east-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1481.0_1.0.392.0
+  us-east-1 (US East (N. Virginia)):      767398015722.dkr.ecr.us-east-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
+  us-west-2 (US West (Oregon)):           905418368575.dkr.ecr.us-west-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
+  us-east-2 (US East (Ohio)):             851725546812.dkr.ecr.us-east-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
+  us-west-1 (US West (N. California)):    011528288828.dkr.ecr.us-west-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
+  eu-central-1 (Europe (Frankfurt)):      211125453373.dkr.ecr.eu-central-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
+  eu-north-1 (Europe (Stockholm)):        654654141839.dkr.ecr.eu-north-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
+  eu-west-1 (Europe (Ireland)):           533267293120.dkr.ecr.eu-west-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
+  eu-west-2 (Europe (London)):            011528288831.dkr.ecr.eu-west-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
+  ap-northeast-1 (Asia Pacific (Tokyo)):  533267052152.dkr.ecr.ap-northeast-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
+  ap-south-1 (Asia Pacific (Mumbai)):     011528288864.dkr.ecr.ap-south-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
+  ap-southeast-1 (Asia Pacific (Singapore)): 905418428165.dkr.ecr.ap-southeast-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
+  ap-southeast-2 (Asia Pacific (Sydney)):    851725636348.dkr.ecr.ap-southeast-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
+  sa-east-1 (South America (São Paulo)):     025066253954.dkr.ecr.sa-east-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
   ```
 
 ## 7. Troubleshooting


### PR DESCRIPTION
Release new version for Health Monitoring Agent 1.0.1892.0_1.0.424.0 with bug fixes.

Bug Fixes

* Add 2 min sleep before nvml component checks to prevent missing GPU false positives

## What's changing and why?
When HMA is upgraded on some older HyperPod AMIs, the NVML component check will return 0 GPUs despite the underlying instance having the correct number of GPUs available. This GPU count mismatch causes HMA to reboot the instance. The issue disappears on the instance after a couple of minutes. Therefore, a 2 min sleep is being added before NVML component checks in order to prevent GPU count mismatch false positives. 

## Before/After UX
N/A - No UX change. 


## How was this change tested?
The new Health Monitoring Agent image (1.0.1892.0_1.0.424.0) has been internally tested and validated through the model change management process. This PR updates the default image tag in the Helm chart to make the new version available to external customers.

## Are unit tests added?
N/A

## Are integration tests added?
N/A

## Reviewer Guidelines


‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [x] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only