### PR TITLE
fix: rename lr_warmup_ratio to lr_warmup_steps_ratio to match recipe

### DIFF
--- a/src/sagemaker/hyperpod/cli/recipe_param_order.py
+++ b/src/sagemaker/hyperpod/cli/recipe_param_order.py
@@ -49,7 +49,7 @@ _PARAM_ORDER: list[tuple[str, str]] = [
     ("max_steps",               "Core Hyperparameters"),
 
     # Advanced Hyperparameters (includes technique-specific params)
-    ("lr_warmup_ratio",         "Advanced Hyperparameters"),
+    ("lr_warmup_steps_ratio",   "Advanced Hyperparameters"),
     ("max_context_length",      "Advanced Hyperparameters"),
     ("max_prompt_length",       "Advanced Hyperparameters"),
     ("max_length",              "Advanced Hyperparameters"),

--- a/test/integration_tests/init/test_recipe_job_creation.py
+++ b/test/integration_tests/init/test_recipe_job_creation.py
@@ -97,7 +97,7 @@ def test_configure_recipe_job(runner, job_name, test_directory):
         "--data-path", "/data/recipes-data/sft/zc_train_256.jsonl",
         "--global-batch-size", "8",
         "--learning-rate", "0.0001",
-        "--lr-warmup-ratio", "0.1",
+        "--lr-warmup-steps-ratio", "0.1",
         "--max-epochs", "20", 
         "--output-path", "/data/output/qwen3-sft",
         "--results-directory", "/data/results/qwen3-sft",


### PR DESCRIPTION
The SageMaker Hub recipes renamed the hyperparameter lr_warmup_ratio to lr_warmup_steps_ratio. This affects all recipes (confirmed on Qwen/Qwen3-4B and meta-llama/Llama-3.1-8B). The CLI's configure command dynamically generates options from the recipe schema, so the actual CLI option is now --lr-warmup-steps-ratio. Updating the parameter name accordingly

## What's changing and why?
<!-- Describe what you're changing and the motivation behind it -->


## Before/After UX
<!-- Show the user experience before and after your changes -->
**Before:**


**After:**


## How was this change tested?
<!-- Describe your testing approach -->


## Are unit tests added?


## Are integration tests added?


## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [ ] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only