### PR TITLE
Release v3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v3.9.0 (2026-06-11)
+
+### Features
+- Support generic `{ide}-remote` connection types for space access (#414)
+- Add v1.1 Space parameters (`queue_name`, `priority` for task governance) and addon version validation warning; bump space template to v1.1.0 (#421)
+- Add v1.2 schema support for custom and jumpstart inference endpoints (#417)
+
+### Inference Operator
+- Update inference helm chart to v2.1.1 with latest CRDs (init container support, custom service accounts, templated manager config) (#416, #418)
+- DPD CRD changes with chart version bump to v3.2; pin operator to amd64 nodes via nodeAffinity; bump inference-operator subchart to v2.2.1 (#427)
+
+### GPU Operator
+- Upgrade GPU Operator v25.3.4 → v26.3.1 to remediate CVEs in base images (#415, #419)
+- Add ap-south-2 (HYD) ECR regional-values for GPU operator (#424)
+
+### Health Monitoring Agent
+- Release Health Monitoring Agent 1.0.1892.0_1.0.424.0 with bug fixes (add 2 min sleep before nvml component checks to prevent missing GPU false positives) (#425)
+
+### Bug Fixes
+- Exclude `kubernetes==36.0.0` which breaks EKS auth and relax `pyyaml` pin (#426)
+- Rename `lr_warmup_ratio` to `lr_warmup_steps_ratio` to match Hub recipe schema (#428)
+
 ## v3.8.0 (2026-04-16)
 
 ### Features

--- a/hyperpod-custom-inference-template/CHANGELOG.md
+++ b/hyperpod-custom-inference-template/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.2.1 (2026-06-11)
+
+### Features
+
+* Add v1.2 schema and template support for custom inference endpoints (#417)
+
 ## v1.2.0 (2025-11-21)
 
 ### Features

--- a/hyperpod-custom-inference-template/pyproject.toml
+++ b/hyperpod-custom-inference-template/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hyperpod-custom-inference-template"
-version = "1.2.0"
+version = "1.2.1"
 readme = "README.md"
 authors = [{name = "Amazon Web Services"}]
 license = {text = "Apache-2.0"}

--- a/hyperpod-jumpstart-inference-template/CHANGELOG.md
+++ b/hyperpod-jumpstart-inference-template/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.2.0 (2026-06-11)
+
+### Features
+
+* Add v1.2 schema and template support for JumpStart inference endpoints (#417)
+
 ## v1.1.1 (2025-11-25)
 
 ### Features

--- a/hyperpod-jumpstart-inference-template/pyproject.toml
+++ b/hyperpod-jumpstart-inference-template/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hyperpod-jumpstart-inference-template"
-version = "1.1.1"
+version = "1.2.0"
 readme = "README.md"
 authors = [{name = "Amazon Web Services"}]
 license = {text = "Apache-2.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 dynamic = ["dependencies"]
 name = "sagemaker-hyperpod"
-version = "3.8.0"
+version = "3.9.0"
 description = "Amazon SageMaker HyperPod SDK and CLI"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ for root, dirs, files in os.walk(
 setup(
     data_files=sagemaker_hyperpod_recipes,
     name="sagemaker-hyperpod",
-    version="3.8.0",
+    version="3.9.0",
     description="Amazon SageMaker HyperPod SDK and CLI",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## What's changing and why?
Release v3.9.0. Rolls up all changes merged since v3.8.0 (#411).

### Version bumps
- `sagemaker-hyperpod`: 3.8.0 → **3.9.0**
- `hyperpod-jumpstart-inference-template`: 1.1.1 → **1.2.0** (now exposes schema v1.2)
- `hyperpod-custom-inference-template`: 1.2.0 → **1.2.1** (captures v1.2 schema code shipped in #417)
- `hyperpod-space-template`: already at 1.1.0 (bumped in #421)

`hyperpod-cluster-stack-template` (1.0.2) and `hyperpod-pytorch-job-template` (1.5.0) are unchanged since v3.8.0, so their versions are left as-is.

### Included since v3.8.0
**Features**
- Support generic `{ide}-remote` connection types for space access (#414)
- Add v1.1 Space parameters (`queue_name`, `priority`) and addon version validation warning; space template → v1.1.0 (#421)
- Add v1.2 schema support for custom and jumpstart inference endpoints (#417)

**Inference Operator**
- Update inference helm chart to v2.1.1 with latest CRDs (#416, #418)
- DPD CRD changes, chart bump to v3.2, pin operator to amd64 nodes, inference-operator subchart → v2.2.1 (#427)

**GPU Operator**
- Upgrade GPU Operator v25.3.4 → v26.3.1 (CVE remediation) (#415, #419)
- Add ap-south-2 (HYD) ECR regional-values (#424)

**Health Monitoring Agent**
- Release HMA 1.0.1892.0_1.0.424.0 with bug fixes (#425)

**Bug Fixes**
- Exclude `kubernetes==36.0.0` (breaks EKS auth) and relax `pyyaml` pin (#426)
- Rename `lr_warmup_ratio` → `lr_warmup_steps_ratio` to match Hub recipe schema (#428)

## How was this change tested?
Version/changelog-only release PR. No functional code changes beyond the version bumps; the underlying changes were tested in their respective PRs.

## Are unit tests added?
N/A — release PR.

## Are integration tests added?
N/A — release PR.

## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification.

One of the following must be true:
- [x] Changes are documentation-only