### PR TITLE
Bump inference operator helm chart version to 2.2.2 with InitialRepli…

### DIFF
--- a/helm_chart/HyperPodHelmChart/Chart.yaml
+++ b/helm_chart/HyperPodHelmChart/Chart.yaml
@@ -81,7 +81,7 @@ dependencies:
     repository: "file://charts/team-role-and-bindings"
     condition: team-role-and-bindings.enabled
   - name: hyperpod-inference-operator
-    version: "2.2.1"
+    version: "2.2.2"
     repository: "file://charts/inference-operator"
     condition: inferenceOperators.enabled 
   - name: hyperpod-patching

--- a/helm_chart/HyperPodHelmChart/charts/inference-operator/Chart.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/inference-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.1
+version: 2.2.2
 
 # This is the version number of the application being deployed. Keep this aligned 
 # with operator image MAJOR.MINOR version.

--- a/helm_chart/HyperPodHelmChart/charts/inference-operator/config/crd/inference.sagemaker.aws.amazon.com_inferenceendpointconfigs.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/inference-operator/config/crd/inference.sagemaker.aws.amazon.com_inferenceendpointconfigs.yaml
@@ -53,8 +53,9 @@ spec:
             properties:
               InitialReplicaCount:
                 description: |-
-                  Number of desired pods. This is a pointer to distinguish between explicit
-                  zero and not specified. Defaults to 1.
+                  Deprecated: This field has no effect and will be removed in a future release.
+                  Use spec.replicas for initial pod count and spec.autoScalingSpec.minReplicaCount
+                  for the steady-state floor under autoscaling.
                 format: int32
                 type: integer
               autoScalingSpec:
@@ -6794,8 +6795,9 @@ spec:
             properties:
               InitialReplicaCount:
                 description: |-
-                  Number of desired pods. This is a pointer to distinguish between explicit
-                  zero and not specified. Defaults to 1.
+                  Deprecated: This field has no effect and will be removed in a future release.
+                  Use spec.replicas for initial pod count and spec.autoScalingSpec.minReplicaCount
+                  for the steady-state floor under autoscaling.
                 format: int32
                 type: integer
               autoScalingSpec:


### PR DESCRIPTION
## What's changing and why?

Bumping the `hyperpod-inference-operator` helm chart from `2.2.1` to `2.2.2` to deprecate the `spec.InitialReplicaCount` field on the `InferenceEndpointConfig` CRD.

`InitialReplicaCount` was dead code — defined in the CRD but never read by the controller, and functionally redundant with `spec.Replicas` (with the `currentReplicas` guard already in place). The field is kept in the schema for backward compatibility but flagged as deprecated.

Customers should use:
- `spec.replicas` for initial pod count
- `spec.autoScalingSpec.minReplicaCount` for the steady-state floor under autoscaling

Operator `appVersion` is unchanged at `3.2` (no binary changes — chart-only release).

## Before/After UX

**Before:**

```yaml
spec:
  InitialReplicaCount:
    description: |-
      Number of desired pods. This is a pointer to distinguish between explicit
      zero and not specified. Defaults to 1.
    format: int32
    type: integer
```

`kubectl explain inferenceendpointconfig.spec.InitialReplicaCount` returns the misleading "Number of desired pods" doc, suggesting customers should set it. The controller never reads it.

**After:**

```yaml
spec:
  InitialReplicaCount:
    description: |-
      Deprecated: This field has no effect and will be removed in a future release.
      Use spec.replicas for initial pod count and spec.autoScalingSpec.minReplicaCount
      for the steady-state floor under autoscaling.
    format: int32
    type: integer
```

`kubectl explain` now surfaces the deprecation notice with migration guidance.

## How was this change tested?

- `helm lint helm_chart/HyperPodHelmChart/charts/inference-operator` passes
- `helm template helm_chart/HyperPodHelmChart/charts/inference-operator` passes (rendering the deprecated field still works for backward compat)
- The CRD changes were validated end-to-end internally before this mirror PR; the deprecated field continues to be accepted by the API server but is ignored by the operator.

## Are unit tests added?

No — chart-only metadata change; no application code modified.

## Are integration tests added?

No — chart-only metadata change. The deprecation does not change runtime behavior.

## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [ ] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only