### PR TITLE
Add space getting-started reference

### DIFF
--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -9,6 +9,7 @@
 Cluster Management <getting_started/cluster_management>
 Training <getting_started/training>
 Inference <getting_started/inference>
+Space <getting_started/space>
 
 ```
 


### PR DESCRIPTION
## What's changing and why?

Adds "Space" as a new entry in the Getting Started documentation table of contents (`doc/getting_started.md`). This links to the existing `doc/getting_started/space.md` page, making the Space getting-started guide discoverable from the top-level getting started navigation alongside Cluster Management, Training, and Inference.

## Before/After UX

**Before:**

The Getting Started toctree only listed three sections:
- Cluster Management
- Training
- Inference

Users had no way to navigate to the Space getting-started guide from the main Getting Started page.

**After:**

The Getting Started toctree now includes four sections:
- Cluster Management
- Training
- Inference
- Space

Users can navigate directly to the Space getting-started guide from the Getting Started page.

## How was this change tested?

This is a documentation-only change (adding a toctree entry). Verified that the target file `doc/getting_started/space.md` exists.

## Are unit tests added?

No — documentation-only change, no unit tests needed.

## Are integration tests added?

No — documentation-only change, no integration tests needed.

## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification.

One of the following must be true:
- [x] Changes are documentation-only
