### PR TITLE
docs: align HMA supported-regions list with _helpers.tpl region map

### DIFF
--- a/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/values.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/values.yaml
@@ -12,11 +12,12 @@ namespace: "aws-hyperpod"
 #    - Node topology labels (topology.kubernetes.io/region)
 #    - AWS provider IDs in node specifications
 #    - Legacy region labels (failure-domain.beta.kubernetes.io/region)
-# 4. Default fallback: us-west-2
+# 4. Default fallback: us-east-1
 #
-# Supported regions: us-east-1, us-west-2, us-east-2, us-west-1, eu-central-1, 
-# eu-north-1, eu-west-1, eu-west-2, ap-northeast-1, ap-south-1, ap-southeast-1, 
-# ap-southeast-2, sa-east-1
+# Supported regions: us-east-1, us-west-2, us-east-2, us-west-1, eu-central-1,
+# eu-north-1, eu-west-1, eu-west-2, eu-south-2, ap-northeast-1, ap-south-1,
+# ap-southeast-1, ap-southeast-2, ap-southeast-3, ap-southeast-4, ca-central-1,
+# sa-east-1
 region: ""
 
 # Image tag for health monitoring agent

--- a/helm_chart/readme.md
+++ b/helm_chart/readme.md
@@ -242,10 +242,14 @@ helm upgrade dependencies helm_chart/HyperPodHelmChart --namespace kube-system
   eu-north-1 (Europe (Stockholm)):        654654141839.dkr.ecr.eu-north-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
   eu-west-1 (Europe (Ireland)):           533267293120.dkr.ecr.eu-west-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
   eu-west-2 (Europe (London)):            011528288831.dkr.ecr.eu-west-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
+  eu-south-2 (Europe (Spain)):            626887787726.dkr.ecr.eu-south-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
   ap-northeast-1 (Asia Pacific (Tokyo)):  533267052152.dkr.ecr.ap-northeast-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
   ap-south-1 (Asia Pacific (Mumbai)):     011528288864.dkr.ecr.ap-south-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
   ap-southeast-1 (Asia Pacific (Singapore)): 905418428165.dkr.ecr.ap-southeast-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
   ap-southeast-2 (Asia Pacific (Sydney)):    851725636348.dkr.ecr.ap-southeast-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
+  ap-southeast-3 (Asia Pacific (Jakarta)):   971422672635.dkr.ecr.ap-southeast-3.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
+  ap-southeast-4 (Asia Pacific (Melbourne)): 084375568333.dkr.ecr.ap-southeast-4.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
+  ca-central-1 (Canada (Central)):        843976229209.dkr.ecr.ca-central-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
   sa-east-1 (South America (São Paulo)):     025066253954.dkr.ecr.sa-east-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.1892.0_1.0.424.0
   ```
 


### PR DESCRIPTION
The supported-regions documentation in readme.md and the HMA chart values.yaml lagged behind the actual region->ECR-account map in _helpers.tpl. eu-south-2, ap-southeast-3, ap-southeast-4, and ca-central-1 are rendered correctly by the chart but were missing from the docs; the values.yaml fallback note also said us-west-2 while the code falls back to us-east-1. Sync both to the 17-region map.

## What's changing and why?
<!-- Describe what you're changing and the motivation behind it -->


## Before/After UX
<!-- Show the user experience before and after your changes -->
**Before:**


**After:**


## How was this change tested?
<!-- Describe your testing approach -->


## Are unit tests added?


## Are integration tests added?


## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [ ] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only