### PR TITLE
Release new version for Health Monitoring Agent 1.0.2297.0_1.0.474.0 …

### DIFF
--- a/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/templates/_helpers.tpl
+++ b/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/templates/_helpers.tpl
@@ -55,7 +55,7 @@ Generate the health monitoring agent image URI based on AWS region
 */}}
 {{- define "health-monitoring-agent.imageUri" -}}
 {{- $region := "" -}}
-{{- $imageTag := .Values.imageTag | default "1.0.2239.0_1.0.456.0" -}}
+{{- $imageTag := .Values.imageTag | default "1.0.2297.0_1.0.474.0" -}}
 
 {{/* Debug: Show image tag selection if debug is enabled */}}
 {{- if .Values.debug -}}

--- a/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/templates/health-monitoring-agent.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/templates/health-monitoring-agent.yaml
@@ -110,6 +110,12 @@ spec:
                       - ml.g6e.12xlarge
                       - ml.g6e.24xlarge
                       - ml.g6e.48xlarge
+                      - ml.g7.2xlarge
+                      - ml.g7.4xlarge
+                      - ml.g7.8xlarge
+                      - ml.g7.12xlarge
+                      - ml.g7.24xlarge
+                      - ml.g7.48xlarge
                       - ml.g7e.2xlarge
                       - ml.g7e.4xlarge
                       - ml.g7e.8xlarge

--- a/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/values.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/values.yaml
@@ -25,7 +25,7 @@ imageTag: ""
 
 # Override the health monitoring agent image URI
 # If specified, this will override the automatic region-based URI selection
-# Example: "905418368575.dkr.ecr.us-west-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2239.0_1.0.456.0"
+# Example: "905418368575.dkr.ecr.us-west-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2297.0_1.0.474.0"
 hmaimage: ""
 
 # Enable debug output for region selection process

--- a/helm_chart/readme.md
+++ b/helm_chart/readme.md
@@ -234,19 +234,19 @@ helm upgrade dependencies helm_chart/HyperPodHelmChart --namespace kube-system
 
 - **Supported Regions and their ECR URIs**:
   ```
-  us-east-1 (US East (N. Virginia)):      767398015722.dkr.ecr.us-east-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2239.0_1.0.456.0
-  us-west-2 (US West (Oregon)):           905418368575.dkr.ecr.us-west-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2239.0_1.0.456.0
-  us-east-2 (US East (Ohio)):             851725546812.dkr.ecr.us-east-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2239.0_1.0.456.0
-  us-west-1 (US West (N. California)):    011528288828.dkr.ecr.us-west-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2239.0_1.0.456.0
-  eu-central-1 (Europe (Frankfurt)):      211125453373.dkr.ecr.eu-central-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2239.0_1.0.456.0
-  eu-north-1 (Europe (Stockholm)):        654654141839.dkr.ecr.eu-north-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2239.0_1.0.456.0
-  eu-west-1 (Europe (Ireland)):           533267293120.dkr.ecr.eu-west-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2239.0_1.0.456.0
-  eu-west-2 (Europe (London)):            011528288831.dkr.ecr.eu-west-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2239.0_1.0.456.0
-  ap-northeast-1 (Asia Pacific (Tokyo)):  533267052152.dkr.ecr.ap-northeast-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2239.0_1.0.456.0
-  ap-south-1 (Asia Pacific (Mumbai)):     011528288864.dkr.ecr.ap-south-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2239.0_1.0.456.0
-  ap-southeast-1 (Asia Pacific (Singapore)): 905418428165.dkr.ecr.ap-southeast-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2239.0_1.0.456.0
-  ap-southeast-2 (Asia Pacific (Sydney)):    851725636348.dkr.ecr.ap-southeast-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2239.0_1.0.456.0
-  sa-east-1 (South America (São Paulo)):     025066253954.dkr.ecr.sa-east-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2239.0_1.0.456.0
+  us-east-1 (US East (N. Virginia)):      767398015722.dkr.ecr.us-east-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2297.0_1.0.474.0
+  us-west-2 (US West (Oregon)):           905418368575.dkr.ecr.us-west-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2297.0_1.0.474.0
+  us-east-2 (US East (Ohio)):             851725546812.dkr.ecr.us-east-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2297.0_1.0.474.0
+  us-west-1 (US West (N. California)):    011528288828.dkr.ecr.us-west-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2297.0_1.0.474.0
+  eu-central-1 (Europe (Frankfurt)):      211125453373.dkr.ecr.eu-central-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2297.0_1.0.474.0
+  eu-north-1 (Europe (Stockholm)):        654654141839.dkr.ecr.eu-north-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2297.0_1.0.474.0
+  eu-west-1 (Europe (Ireland)):           533267293120.dkr.ecr.eu-west-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2297.0_1.0.474.0
+  eu-west-2 (Europe (London)):            011528288831.dkr.ecr.eu-west-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2297.0_1.0.474.0
+  ap-northeast-1 (Asia Pacific (Tokyo)):  533267052152.dkr.ecr.ap-northeast-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2297.0_1.0.474.0
+  ap-south-1 (Asia Pacific (Mumbai)):     011528288864.dkr.ecr.ap-south-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2297.0_1.0.474.0
+  ap-southeast-1 (Asia Pacific (Singapore)): 905418428165.dkr.ecr.ap-southeast-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2297.0_1.0.474.0
+  ap-southeast-2 (Asia Pacific (Sydney)):    851725636348.dkr.ecr.ap-southeast-2.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2297.0_1.0.474.0
+  sa-east-1 (South America (São Paulo)):     025066253954.dkr.ecr.sa-east-1.amazonaws.com/hyperpod-health-monitoring-agent:1.0.2297.0_1.0.474.0
   ```
 
 ## 7. Troubleshooting


### PR DESCRIPTION
…with g7 and trn2.3xlarge instance support updates

## What's changing and why?
- Add HMA support for G7 and trn2.3xlarge instance family


## Before/After UX
no UX change.


## How was this change tested?
The new Health Monitoring Agent image (1.0.2297.0_1.0.474.0) has been internally tested and validated through the model change management process. This PR updates the default image tag in the Helm chart to make the new version available to external customers.

## Are unit tests added?
N/a

## Are integration tests added?
N.a

## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [x] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only