### PR TITLE
feat: add trn2.3xlarge to neuron-device-plugin.yaml

### DIFF
--- a/helm_chart/HyperPodHelmChart/charts/neuron-device-plugin/templates/k8s-neuron-device-plugin.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/neuron-device-plugin/templates/k8s-neuron-device-plugin.yaml
@@ -60,6 +60,7 @@ spec:
                       - ml.trn1.2xlarge
                       - ml.trn1.32xlarge
                       - ml.trn1n.32xlarge
+                      - ml.trn2.3xlarge
                       - ml.trn2.48xlarge
       containers:
         # Find all neuron-device-plugin images at https://gallery.ecr.aws/neuron/neuron-device-plugin


### PR DESCRIPTION
## What's changing and why?
Add `trn2.3xlarge` to neuron-device-plugin.yaml to enable `trn2.3xlarge` support on HyperPod


## Before/After UX
<!-- Show the user experience before and after your changes -->
**Before:**
`trn2.3xlarge` would not have `neuron-device-plugin` pod scheduled on it.

**After:**
`trn2.3xlarge` has `neuron-device-plugin` pod scheduled on it.

## How was this change tested?
Created HyperPod cluster and scaled up `trn2.3xlarge` instances and verified pods run:
```
dev-dsk-gabepasc-2b-3b04a487 % kubectl get pods -A
NAMESPACE      NAME                                   READY   STATUS              RESTARTS       AGE
aws-hyperpod   health-monitoring-agent-gk8gd          0/1     RunContainerError   955 (1s ago)   3d9h
kube-system    aws-node-6ktcj                         2/2     Running             0              3d11h
kube-system    coredns-7468d594c9-fsfzh               1/1     Running             0              3d13h
kube-system    coredns-7468d594c9-nd7v9               1/1     Running             0              3d13h
kube-system    eks-pod-identity-agent-px8bb           1/1     Running             0              3d11h
kube-system    kube-proxy-6qgjs                       1/1     Running             0              3d11h
kube-system    neuron-device-plugin-daemonset-hk6zg   1/1     Running             0              31s

dev-dsk-gabepasc-2b-3b04a487 % kubectl describe node hyperpod-i-0f7d6c2b34324bafd | grep -E "neurondevice|efa|cpu"
  aws.amazon.com/neurondevice:  1
  cpu:                          12
  aws.amazon.com/neurondevice:  1
  cpu:                          11900m
  cpu                          850m (7%)   500m (4%)
  aws.amazon.com/neurondevice  0           0
```


## Are unit tests added?
NA


## Are integration tests added?
NA


## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [ ] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only