### PR TITLE
[DO NOT MERGE] Add hyperpod-ray-endpoint-operator to HyperPod Helm chart

### DIFF
--- a/helm_chart/HyperPodHelmChart/Chart.yaml
+++ b/helm_chart/HyperPodHelmChart/Chart.yaml
@@ -92,3 +92,7 @@ dependencies:
     version: "0.1.0"
     repository: "file://charts/gpu-operator"
     condition: gpu-operator.enabled
+  - name: hyperpod-ray-endpoint-operator
+    version: "0.1.0"
+    repository: "file://charts/hyperpod-ray-endpoint-operator"
+    condition: hyperpod-ray-endpoint-operator.enabled

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/Chart.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: hyperpod-ray-endpoint-operator
+description: A Helm chart to distribute hyperpod-ray-endpoint-operator
+type: application
+
+version: 0.1.0
+appVersion: "0.1.0"
+
+keywords:
+  - kubernetes
+  - operator
+
+annotations:
+  kubebuilder.io/generated-by: kubebuilder

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/crds/hyperpodrayendpointaccessstrategies.access.sagemaker.amazonaws.com.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/crds/hyperpodrayendpointaccessstrategies.access.sagemaker.amazonaws.com.yaml
@@ -1,0 +1,99 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/resource-policy": keep
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: hyperpodrayendpointaccessstrategies.access.sagemaker.amazonaws.com
+spec:
+  group: access.sagemaker.amazonaws.com
+  names:
+    kind: HyperpodRayEndpointAccessStrategy
+    listKind: HyperpodRayEndpointAccessStrategyList
+    plural: hyperpodrayendpointaccessstrategies
+    singular: hyperpodrayendpointaccessstrategy
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: HyperpodRayEndpointAccessStrategy defines how dashboard access
+          is configured for RayClusters.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HyperpodRayEndpointAccessStrategySpec defines the desired
+              state of HyperpodRayEndpointAccessStrategy.
+            properties:
+              accessResourceTemplates:
+                description: AccessResourceTemplates defines Kubernetes resources
+                  to create per RayCluster.
+                items:
+                  description: AccessResourceTemplate defines a templated resource
+                    the controller creates per RayCluster.
+                  properties:
+                    apiVersion:
+                      description: APIVersion of the resource.
+                      type: string
+                    kind:
+                      description: Kind of the resource (e.g., IngressRoute).
+                      type: string
+                    namePrefix:
+                      description: NamePrefix is prepended to the RayCluster name
+                        to form the resource name.
+                      type: string
+                    template:
+                      description: Template is a Go template that renders the resource
+                        spec.
+                      type: string
+                  required:
+                  - apiVersion
+                  - kind
+                  - namePrefix
+                  - template
+                  type: object
+                type: array
+              accessType:
+                description: 'AccessType controls ownership checks: "ownerOnly" or
+                  "public".'
+                enum:
+                - ownerOnly
+                - public
+                type: string
+              bearerAuthURLTemplate:
+                description: |-
+                  BearerAuthURLTemplate is a Go template for generating the dashboard URL.
+                  Available variables: .RayCluster.Name, .RayCluster.Namespace, .RayCluster.EncodedNamespace, .Domain
+                type: string
+              displayName:
+                description: DisplayName is a human-readable name for this strategy.
+                type: string
+            required:
+            - accessType
+            - bearerAuthURLTemplate
+            type: object
+          status:
+            description: HyperpodRayEndpointAccessStrategyStatus defines the observed
+              state.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/NOTES.txt
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/NOTES.txt
@@ -1,0 +1,15 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+The controller and CRDs have been installed in namespace {{ .Values.namespace }}.
+
+To verify the installation:
+
+  kubectl get pods -n {{ .Values.namespace }}
+  kubectl get customresourcedefinitions
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }} -n {{ .Values.namespace }}
+  $ helm get all {{ .Release.Name }} -n {{ .Values.namespace }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/_helpers.tpl
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/_helpers.tpl
@@ -1,0 +1,120 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hyperpod-ray-endpoint-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "hyperpod-ray-endpoint-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Namespace for generated references.
+Defaults to "hyperpod-ray" unless overridden via values.
+*/}}
+{{- define "hyperpod-ray-endpoint-operator.namespaceName" -}}
+{{- .Values.namespace | default "hyperpod-ray" }}
+{{- end }}
+
+{{/*
+Resource name with proper truncation for Kubernetes 63-character limit.
+Takes a dict with:
+  - .suffix: Resource name suffix (e.g., "metrics", "webhook")
+  - .context: Template context (root context with .Values, .Release, etc.)
+Dynamically calculates safe truncation to ensure total name length <= 63 chars.
+*/}}
+{{- define "hyperpod-ray-endpoint-operator.resourceName" -}}
+{{- $fullname := include "hyperpod-ray-endpoint-operator.fullname" .context }}
+{{- $suffix := .suffix }}
+{{- $maxLen := sub 62 (len $suffix) | int }}
+{{- if gt (len $fullname) $maxLen }}
+{{- printf "%s-%s" (trunc $maxLen $fullname | trimSuffix "-") $suffix | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" $fullname $suffix | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+ServiceAccount name to use.
+If serviceAccount.enable is false and serviceAccount.name is set, use that name.
+Otherwise, use the standard resourceName helper with "controller-manager" suffix.
+*/}}
+{{- define "hyperpod-ray-endpoint-operator.serviceAccountName" -}}
+{{- if and (hasKey .Values.serviceAccount "enable") (not .Values.serviceAccount.enable) .Values.serviceAccount.name }}
+{{- .Values.serviceAccount.name }}
+{{- else }}
+{{- include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "controller-manager" "context" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the container image URI.
+Priority for region:
+  1. .Values.region (explicit setting)
+  2. .Values.global.region (global setting from parent chart)
+  3. fail — region is required
+
+Priority for image URI:
+  1. .Values.image.override (full URI override, skips all resolution)
+  2. Constructed from region→account mapping + repository name + tag
+*/}}
+{{- define "hyperpod-ray-endpoint-operator.imageUri" -}}
+{{- if .Values.image.override -}}
+  {{- .Values.image.override -}}
+{{- else -}}
+{{- $region := "" -}}
+{{- if .Values.region -}}
+  {{- $region = .Values.region -}}
+{{- else if and .Values.global .Values.global.region -}}
+  {{- $region = .Values.global.region -}}
+{{- else -}}
+  {{- fail "region is required when image.override is not set. Set region or global.region." -}}
+{{- end -}}
+
+{{/* Region to ECR account ID mapping */}}
+{{- $regionAccountMap := dict
+  "ca-central-1" "983936648948"
+  "us-east-1" "622623004016"
+  "us-east-2" "084149021266"
+  "us-west-1" "647106553245"
+  "us-west-2" "148286033537"
+  "eu-west-1" "125579686045"
+  "eu-west-2" "391701072240"
+  "eu-central-1" "368999588123"
+  "eu-north-1" "064032700373"
+  "eu-south-2" "984149068489"
+  "ap-northeast-1" "325771561645"
+  "ap-northeast-2" "883353268341"
+  "ap-south-1" "883218392248"
+  "ap-south-2" "392424878547"
+  "ap-southeast-1" "850032337960"
+  "ap-southeast-2" "504110891989"
+  "ap-southeast-3" "772699011045"
+  "ap-southeast-4" "357229908674"
+  "sa-east-1" "126458881049"
+-}}
+
+{{- $accountId := index $regionAccountMap $region -}}
+{{- if not $accountId -}}
+  {{- fail (printf "Unsupported AWS region: %s. Set image.override explicitly for non-standard regions." $region) -}}
+{{- end -}}
+
+{{- $imageTag := .Values.image.tag | default "1.0.188.0_1.0.19.0" -}}
+{{- printf "%s.dkr.ecr.%s.amazonaws.com/hyperpod-ray-endpoint-operator:%s" $accountId $region $imageTag -}}
+{{- end -}}
+{{- end }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/cert-manager/extension-api-cert.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/cert-manager/extension-api-cert.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.certManager.enable }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "extension-api-cert" "context" $) }}
+  namespace: {{ .Values.namespace }}
+spec:
+  commonName: extension-api
+  dnsNames:
+  - {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "extension-api" "context" $) }}.{{ .Values.namespace }}.svc
+  - {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "extension-api" "context" $) }}.{{ .Values.namespace }}.svc.cluster.local
+  duration: 2160h
+  issuerRef:
+    kind: Issuer
+    name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "selfsigned-issuer" "context" $) }}
+  privateKey:
+    rotationPolicy: Always
+  renewBefore: 360h
+  secretName: extension-api-cert
+  subject:
+    organizations:
+    - hyperpod-ray-endpoint-operator
+{{- end }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/cert-manager/selfsigned-issuer.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/cert-manager/selfsigned-issuer.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.certManager.enable }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "selfsigned-issuer" "context" $) }}
+  namespace: {{ .Values.namespace }}
+spec:
+  selfSigned: {}
+{{- end }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/cert-manager/serving-cert.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/cert-manager/serving-cert.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.certManager.enable }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "serving-cert" "context" $) }}
+  namespace: {{ .Values.namespace }}
+spec:
+  dnsNames:
+  - {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}.{{ .Values.namespace }}.svc
+  - {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}.{{ .Values.namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "selfsigned-issuer" "context" $) }}
+  secretName: webhook-server-cert
+{{- end }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/extras/auth-middleware.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/extras/auth-middleware.yaml
@@ -1,0 +1,133 @@
+{{- if or (not (hasKey .Values.authMiddleware "enabled")) (.Values.authMiddleware.enabled) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: auth-middleware
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "auth-middleware" "context" $) }}
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.authMiddleware.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+      app.kubernetes.io/component: auth-middleware
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/component: auth-middleware
+    spec:
+      {{- with .Values.authMiddleware.tolerations }}
+      tolerations: {{ toYaml . | nindent 10 }}
+      {{- end }}
+      containers:
+      - command:
+        - /authmiddleware
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: PORT
+          value: {{ .Values.authMiddleware.env.port | quote }}
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: JWT_SECRET_NAME
+          value: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "extensionapi-jwt-secret" "context" $) | quote }}
+        - name: JWT_ISSUER
+          value: {{ .Values.authMiddleware.env.jwtIssuer | quote }}
+        - name: JWT_AUDIENCE
+          value: {{ .Values.authMiddleware.env.jwtAudience | quote }}
+        - name: SESSION_TTL
+          value: {{ .Values.authMiddleware.env.sessionTTL | quote }}
+        - name: COOKIE_NAME
+          value: {{ .Values.authMiddleware.env.cookieName | quote }}
+        - name: COOKIE_SECURE
+          value: {{ .Values.authMiddleware.env.cookieSecure | quote }}
+        - name: COOKIE_SAMESITE
+          value: {{ .Values.authMiddleware.env.cookieSameSite | quote }}
+        - name: LOG_FILE_PATH
+          value: {{ .Values.authMiddleware.env.logFilePath | quote }}
+        image: {{ include "hyperpod-ray-endpoint-operator.imageUri" . }}
+        {{- with .Values.authMiddleware.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        name: authmiddleware
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          {{- toYaml .Values.authMiddleware.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.authMiddleware.securityContext | nindent 10 }}
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+        - mountPath: /var/log/aws/clusters
+          name: log
+      {{- with .Values.authMiddleware.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 10 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.authMiddleware.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "auth-middleware" "context" $) }}
+      {{- if and (hasKey .Values.authMiddleware "terminationGracePeriodSeconds") (ne .Values.authMiddleware.terminationGracePeriodSeconds nil) }}
+      terminationGracePeriodSeconds: {{ .Values.authMiddleware.terminationGracePeriodSeconds }}
+      {{- end }}
+      volumes:
+      - emptyDir: {}
+        name: tmp
+      - hostPath:
+          path: /var/log/aws/clusters/
+        name: log
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: auth-middleware
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "auth-middleware" "context" $) }}
+  namespace: {{ .Values.namespace }}
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app.kubernetes.io/component: auth-middleware
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+  type: ClusterIP
+{{- end }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/extras/extension-api.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/extras/extension-api.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "extension-api" "context" $) }}
+  namespace: {{ .Values.namespace }}
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 7443
+  selector:
+    control-plane: controller-manager
+  type: ClusterIP

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/extras/extensionapi-jwt-secret.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/extras/extensionapi-jwt-secret.yaml
@@ -1,0 +1,10 @@
+{{- $secretName := include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "extensionapi-jwt-secret" "context" $) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: extensionapi-jwt
+    component: security
+  name: {{ $secretName }}
+  namespace: {{ .Values.namespace }}
+type: Opaque

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/extras/jwt-rotator.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/extras/jwt-rotator.yaml
@@ -1,0 +1,125 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  labels:
+    app.kubernetes.io/component: jwt-rotator
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "jwt-rotator" "context" $) }}
+  namespace: {{ .Values.namespace }}
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: jwt-rotator
+            app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+            helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+            app.kubernetes.io/instance: {{ .Release.Name }}
+            app.kubernetes.io/managed-by: {{ .Release.Service }}
+        spec:
+          containers:
+          - command:
+            - /rotator
+            - --secret-name={{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "extensionapi-jwt-secret" "context" $) }}
+            - --secret-namespace={{ .Values.namespace }}
+            - --number-of-keys=13
+            {{- if .Values.kmsKeyArn }}
+            - --kms-key-arn={{ .Values.kmsKeyArn }}
+            {{- end }}
+            image: {{ include "hyperpod-ray-endpoint-operator.imageUri" . }}
+            name: rotator
+            resources:
+              limits:
+                cpu: 100m
+                memory: 128Mi
+              requests:
+                cpu: 50m
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: true
+          # Never (not OnFailure) so failed pods are preserved for log inspection.
+          # With OnFailure, pods are deleted after backoffLimit and logs are lost.
+          restartPolicy: Never
+          securityContext:
+            fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "jwt-rotator" "context" $) }}
+  schedule: '*/30 * * * *'
+  successfulJobsHistoryLimit: 3
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app.kubernetes.io/component: jwt-rotator
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "jwt-rotator-init" "context" $) }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: jwt-rotator
+        app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+    spec:
+      containers:
+      - command:
+        - /rotator
+        - --secret-name={{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "extensionapi-jwt-secret" "context" $) }}
+        - --secret-namespace={{ .Values.namespace }}
+        - --number-of-keys=13
+        {{- if .Values.kmsKeyArn }}
+        - --kms-key-arn={{ .Values.kmsKeyArn }}
+        {{- end }}
+        image: {{ include "hyperpod-ray-endpoint-operator.imageUri" . }}
+        imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
+        name: rotator
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+      # Never (not OnFailure) so failed pods are preserved for log inspection.
+      # With OnFailure, pods are deleted after backoffLimit and logs are lost.
+      restartPolicy: Never
+      securityContext:
+        fsGroup: 65532
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "jwt-rotator" "context" $) }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/extras/runtime-config.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/extras/runtime-config.yaml
@@ -1,0 +1,187 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: strip-bearer-auth-suffix
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    app.kubernetes.io/component: traefik-middleware
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replacePathRegex:
+    regex: "^/bearer-auth(.*)$"
+    replacement: "/$1"
+---
+apiVersion: access.sagemaker.amazonaws.com/v1alpha1
+kind: HyperpodRayEndpointAccessStrategy
+metadata:
+  name: ray-access-strategy-private
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    app.kubernetes.io/component: access-strategy
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  accessType: ownerOnly
+  bearerAuthURLTemplate: "https://{{`{{ .RayCluster.Name }}-{{ .RayCluster.EncodedNamespace }}.{{ .Domain }}`}}/bearer-auth"
+  accessResourceTemplates:
+    - kind: Middleware
+      apiVersion: traefik.io/v1alpha1
+      namePrefix: cluster-forward-auth
+      template: |
+        spec:
+          forwardAuth:
+            address: "http://{{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "auth-middleware" "context" $) }}.{{ .Values.namespace }}.svc.cluster.local:8080/verify?cluster-uid={{`{{ .RayCluster.UID }}`}}"
+            trustForwardHeader: false
+            addAuthCookiesToResponse:
+              - ray_session
+            authRequestHeaders:
+              - Host
+              - X-Forwarded-Host
+              - X-Forwarded-Uri
+              - Cookie
+              - Authorization
+    - kind: Middleware
+      apiVersion: traefik.io/v1alpha1
+      namePrefix: cluster-bearer-auth
+      template: |
+        spec:
+          forwardAuth:
+            address: "http://{{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "auth-middleware" "context" $) }}.{{ .Values.namespace }}.svc.cluster.local:8080/bearer-auth?cluster-uid={{`{{ .RayCluster.UID }}`}}"
+            trustForwardHeader: false
+            addAuthCookiesToResponse:
+              - ray_session
+            authRequestHeaders:
+              - Host
+              - X-Forwarded-Host
+              - X-Forwarded-Uri
+              - Cookie
+              - Authorization
+    - kind: IngressRoute
+      apiVersion: traefik.io/v1alpha1
+      namePrefix: authorized-route
+      template: |
+        spec:
+          entryPoints:
+            - web
+          routes:
+            - match: "Host(`{{`{{ .RayCluster.Name }}-{{ .RayCluster.EncodedNamespace }}.{{ .Domain }}`}}`)"
+              kind: Rule
+              priority: 100
+              middlewares:
+                - name: cluster-forward-auth-{{`{{ .RayCluster.Name }}`}}
+                  namespace: "{{`{{ .RayCluster.Namespace }}`}}"
+              services:
+                - name: "{{`{{ .RayCluster.Name }}`}}-head-svc"
+                  namespace: "{{`{{ .RayCluster.Namespace }}`}}"
+                  port: {{`{{ .RayCluster.DashboardPort }}`}}
+    - kind: IngressRoute
+      apiVersion: traefik.io/v1alpha1
+      namePrefix: bearer-auth-route
+      template: |
+        spec:
+          entryPoints:
+            - web
+          routes:
+            - match: "Host(`{{`{{ .RayCluster.Name }}-{{ .RayCluster.EncodedNamespace }}.{{ .Domain }}`}}`) && PathPrefix(`/bearer-auth`)"
+              kind: Rule
+              priority: 110
+              middlewares:
+                - name: cluster-bearer-auth-{{`{{ .RayCluster.Name }}`}}
+                  namespace: "{{`{{ .RayCluster.Namespace }}`}}"
+                - name: strip-bearer-auth-suffix
+                  namespace: {{ .Values.namespace }}
+              services:
+                - name: "{{`{{ .RayCluster.Name }}`}}-head-svc"
+                  namespace: "{{`{{ .RayCluster.Namespace }}`}}"
+                  port: {{`{{ .RayCluster.DashboardPort }}`}}
+---
+apiVersion: access.sagemaker.amazonaws.com/v1alpha1
+kind: HyperpodRayEndpointAccessStrategy
+metadata:
+  name: ray-access-strategy-public
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    app.kubernetes.io/component: access-strategy
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  accessType: public
+  bearerAuthURLTemplate: "https://{{`{{ .RayCluster.Name }}-{{ .RayCluster.EncodedNamespace }}.{{ .Domain }}`}}/bearer-auth"
+  accessResourceTemplates:
+    - kind: Middleware
+      apiVersion: traefik.io/v1alpha1
+      namePrefix: cluster-forward-auth
+      template: |
+        spec:
+          forwardAuth:
+            address: "http://{{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "auth-middleware" "context" $) }}.{{ .Values.namespace }}.svc.cluster.local:8080/verify?cluster-uid={{`{{ .RayCluster.UID }}`}}"
+            trustForwardHeader: false
+            addAuthCookiesToResponse:
+              - ray_session
+            authRequestHeaders:
+              - Host
+              - X-Forwarded-Host
+              - X-Forwarded-Uri
+              - Cookie
+              - Authorization
+    - kind: Middleware
+      apiVersion: traefik.io/v1alpha1
+      namePrefix: cluster-bearer-auth
+      template: |
+        spec:
+          forwardAuth:
+            address: "http://{{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "auth-middleware" "context" $) }}.{{ .Values.namespace }}.svc.cluster.local:8080/bearer-auth?cluster-uid={{`{{ .RayCluster.UID }}`}}"
+            trustForwardHeader: false
+            addAuthCookiesToResponse:
+              - ray_session
+            authRequestHeaders:
+              - Host
+              - X-Forwarded-Host
+              - X-Forwarded-Uri
+              - Cookie
+              - Authorization
+    - kind: IngressRoute
+      apiVersion: traefik.io/v1alpha1
+      namePrefix: authorized-route
+      template: |
+        spec:
+          entryPoints:
+            - web
+          routes:
+            - match: "Host(`{{`{{ .RayCluster.Name }}-{{ .RayCluster.EncodedNamespace }}.{{ .Domain }}`}}`)"
+              kind: Rule
+              priority: 100
+              middlewares:
+                - name: cluster-forward-auth-{{`{{ .RayCluster.Name }}`}}
+                  namespace: "{{`{{ .RayCluster.Namespace }}`}}"
+              services:
+                - name: "{{`{{ .RayCluster.Name }}`}}-head-svc"
+                  namespace: "{{`{{ .RayCluster.Namespace }}`}}"
+                  port: {{`{{ .RayCluster.DashboardPort }}`}}
+    - kind: IngressRoute
+      apiVersion: traefik.io/v1alpha1
+      namePrefix: bearer-auth-route
+      template: |
+        spec:
+          entryPoints:
+            - web
+          routes:
+            - match: "Host(`{{`{{ .RayCluster.Name }}-{{ .RayCluster.EncodedNamespace }}.{{ .Domain }}`}}`) && PathPrefix(`/bearer-auth`)"
+              kind: Rule
+              priority: 110
+              middlewares:
+                - name: cluster-bearer-auth-{{`{{ .RayCluster.Name }}`}}
+                  namespace: "{{`{{ .RayCluster.Namespace }}`}}"
+                - name: strip-bearer-auth-suffix
+                  namespace: {{ .Values.namespace }}
+              services:
+                - name: "{{`{{ .RayCluster.Name }}`}}-head-svc"
+                  namespace: "{{`{{ .RayCluster.Namespace }}`}}"
+                  port: {{`{{ .RayCluster.DashboardPort }}`}}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/extras/v1alpha1.connection.access.sagemaker.amazonaws.com.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/extras/v1alpha1.connection.access.sagemaker.amazonaws.com.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Values.namespace }}/{{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "extension-api-cert" "context" $) }}
+  name: v1alpha1.connection.access.sagemaker.amazonaws.com
+spec:
+  group: connection.access.sagemaker.amazonaws.com
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: false
+  service:
+    name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "extension-api" "context" $) }}
+    namespace: {{ .Values.namespace }}
+  version: v1alpha1
+  versionPriority: 100

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/manager/manager.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/manager/manager.yaml
@@ -1,0 +1,198 @@
+{{- if or (not (hasKey .Values.manager "enabled")) (.Values.manager.enabled) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    control-plane: controller-manager
+    {{- with .Values.manager.labels }}
+    {{- with omit . "app.kubernetes.io/managed-by" "app.kubernetes.io/name" "helm.sh/chart" "app.kubernetes.io/instance" "control-plane" }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- end }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "controller-manager" "context" $) }}
+  namespace: {{ .Values.namespace }}
+  {{- if .Values.manager.annotations }}
+  annotations:
+    {{- toYaml .Values.manager.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.manager.strategy }}
+  strategy: {{ toYaml . | nindent 6 }}
+  {{- end }}
+  replicas: {{ .Values.manager.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+        {{- with .Values.manager.pod }}
+        {{- with .annotations }}
+        {{- with omit . "kubectl.kubernetes.io/default-container" }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        control-plane: controller-manager
+        {{- with .Values.manager.pod }}
+        {{- with .labels }}
+        {{- with omit . "app.kubernetes.io/name" "helm.sh/chart" "app.kubernetes.io/instance" "app.kubernetes.io/managed-by" "control-plane" }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+    spec:
+      {{- with .Values.manager.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .Values.manager.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.manager.tolerations }}
+      tolerations: {{ toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .Values.manager.affinity }}
+      affinity: {{ toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .Values.manager.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - args:
+        {{- if .Values.metrics.enable }}
+        - --metrics-bind-address=:{{ .Values.metrics.port }}
+        {{- if not .Values.metrics.secure }}
+        - --metrics-secure=false
+        {{- end }}
+        {{- else }}
+        # Bind to :0 to disable the controller-runtime managed metrics server
+        - --metrics-bind-address=0
+        {{- end }}
+        - --health-probe-bind-address=:8081
+        - --operator-namespace=$(NAMESPACE)
+        {{- if not (has (toString .Values.manager.enableEndpointsByDefault) (list "true" "false")) }}
+        {{- fail "manager.enableEndpointsByDefault is required and must be set to 'true' or 'false'" }}
+        {{- end }}
+        - --enable-endpoints-by-default={{ .Values.manager.enableEndpointsByDefault }}
+        {{- range .Values.manager.args }}
+        - {{ . }}
+        {{- end }}
+        {{- if .Values.domain }}
+        - --extension-api-domain={{ .Values.domain }}
+        {{- end }}
+        - --extension-api-jwt-secret={{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "extensionapi-jwt-secret" "context" $) }}
+        {{- if .Values.adminGroup }}
+        - --admin-group={{ .Values.adminGroup }}
+        {{- end }}
+        {{- if .Values.certManager.enable }}
+        - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+        {{- end }}
+        command:
+        - /manager
+        env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+{{- if or .Values.manager.env (and (kindIs "map" .Values.manager.envOverrides) (not (empty .Values.manager.envOverrides))) }}
+          {{- if .Values.manager.env }}
+          {{- toYaml .Values.manager.env | nindent 10 }}
+          {{- end }}
+          {{- if kindIs "map" .Values.manager.envOverrides }}
+          {{- range $k, $v := .Values.manager.envOverrides }}
+          - name: {{ $k }}
+            value: {{ $v | quote }}
+          {{ end }}
+          {{- end }}
+          {{- end }}
+        image: {{ include "hyperpod-ray-endpoint-operator.imageUri" . }}
+        {{- with .Values.manager.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 8081
+          name: health
+          protocol: TCP
+        - containerPort: {{ .Values.webhook.port }}
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          {{- if .Values.manager.resources }}
+          {{- toYaml .Values.manager.resources | nindent 10 }}
+          {{- else }}
+          {}
+          {{- end }}
+        securityContext:
+          {{- if .Values.manager.securityContext }}
+          {{- toYaml .Values.manager.securityContext | nindent 10 }}
+          {{- else }}
+          {}
+          {{- end }}
+        volumeMounts:
+          {{- if .Values.manager.extraVolumeMounts }}
+          {{- toYaml .Values.manager.extraVolumeMounts | nindent 10 }}
+          {{- end }}
+          - mountPath: /var/log/aws/clusters
+            name: log
+          - mountPath: /tmp/extension-api/serving-certs
+            name: extension-api-cert
+            readOnly: true
+          {{- if .Values.certManager.enable }}
+          - mountPath: /tmp/k8s-webhook-server/serving-certs
+            name: webhook-certs
+            readOnly: true
+          {{- end }}
+      {{- with .Values.manager.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 10 }}
+      {{- end }}
+      securityContext:
+        {{- if .Values.manager.podSecurityContext }}
+        {{- toYaml .Values.manager.podSecurityContext | nindent 8 }}
+        {{- else }}
+        {}
+        {{- end }}
+      serviceAccountName: {{ include "hyperpod-ray-endpoint-operator.serviceAccountName" . }}
+      {{- if and (hasKey .Values.manager "terminationGracePeriodSeconds") (ne .Values.manager.terminationGracePeriodSeconds nil) }}
+      terminationGracePeriodSeconds: {{ .Values.manager.terminationGracePeriodSeconds }}
+      {{- end }}
+      volumes:
+        {{- if .Values.manager.extraVolumes }}
+        {{- toYaml .Values.manager.extraVolumes | nindent 8 }}
+        {{- end }}
+        - hostPath:
+            path: /var/log/aws/clusters/
+          name: log
+        - name: extension-api-cert
+          secret:
+            secretName: extension-api-cert
+        {{- if .Values.certManager.enable }}
+        - name: webhook-certs
+          secret:
+            secretName: webhook-server-cert
+        {{- end }}
+{{- end }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/metrics/metrics-service.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/metrics/metrics-service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.metrics.enable }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    control-plane: controller-manager
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "metrics-service" "context" $) }}
+  namespace: {{ .Values.namespace }}
+spec:
+  ports:
+  - name: {{ if .Values.metrics.secure }}https{{ else }}http{{ end }}
+    port: {{ .Values.metrics.port }}
+    protocol: TCP
+    targetPort: {{ .Values.metrics.port }}
+  selector:
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    control-plane: controller-manager
+{{- end }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/prometheus/controller-manager-metrics-monitor.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/prometheus/controller-manager-metrics-monitor.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.prometheus.enable }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    control-plane: controller-manager
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "controller-manager-metrics-monitor" "context" $) }}
+  namespace: {{ .Values.namespace }}
+spec:
+  endpoints:
+  - {{- if .Values.metrics.secure }}
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    {{- end }}
+    path: /metrics
+    port: {{ if .Values.metrics.secure }}https{{ else }}http{{ end }}
+    scheme: {{ if .Values.metrics.secure }}https{{ else }}http{{ end }}
+    {{- if .Values.metrics.secure }}
+    tlsConfig:
+      serverName: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "metrics-service" "context" $) }}.{{ .Values.namespace }}.svc
+      {{- if .Values.certManager.enable }}
+      ca:
+        secret:
+          name: metrics-server-cert
+          key: ca.crt
+      cert:
+        secret:
+          name: metrics-server-cert
+          key: tls.crt
+      keySecret:
+        name: metrics-server-cert
+        key: tls.key
+      {{- else }}
+      insecureSkipVerify: true
+      {{- end }}
+    {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+      control-plane: controller-manager
+{{- end }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/access-strategy-admin.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/access-strategy-admin.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.namespaced }}
+kind: Role
+{{- else }}
+kind: ClusterRole
+{{- end }}
+metadata:
+{{- if .Values.rbac.namespaced }}
+  namespace: {{ .Values.namespace }}
+{{- end }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "access-strategy-admin" "context" $) }}
+rules:
+- apiGroups:
+  - access.sagemaker.amazonaws.com
+  resources:
+  - hyperpodrayendpointaccessstrategies
+  verbs:
+  - '*'
+- apiGroups:
+  - access.sagemaker.amazonaws.com
+  resources:
+  - hyperpodrayendpointaccessstrategies/status
+  verbs:
+  - get

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/access-strategy-editor.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/access-strategy-editor.yaml
@@ -1,0 +1,35 @@
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.namespaced }}
+kind: Role
+{{- else }}
+kind: ClusterRole
+{{- end }}
+metadata:
+{{- if .Values.rbac.namespaced }}
+  namespace: {{ .Values.namespace }}
+{{- end }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "access-strategy-editor" "context" $) }}
+rules:
+- apiGroups:
+  - access.sagemaker.amazonaws.com
+  resources:
+  - hyperpodrayendpointaccessstrategies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - access.sagemaker.amazonaws.com
+  resources:
+  - hyperpodrayendpointaccessstrategies/status
+  verbs:
+  - get

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/access-strategy-viewer.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/access-strategy-viewer.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.namespaced }}
+kind: Role
+{{- else }}
+kind: ClusterRole
+{{- end }}
+metadata:
+{{- if .Values.rbac.namespaced }}
+  namespace: {{ .Values.namespace }}
+{{- end }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "access-strategy-viewer" "context" $) }}
+rules:
+- apiGroups:
+  - access.sagemaker.amazonaws.com
+  resources:
+  - hyperpodrayendpointaccessstrategies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - access.sagemaker.amazonaws.com
+  resources:
+  - hyperpodrayendpointaccessstrategies/status
+  verbs:
+  - get

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/auth-mw-node-reader-binding.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/auth-mw-node-reader-binding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: auth-middleware
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "auth-mw-node-reader-binding" "context" $) }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "auth-mw-node-reader" "context" $) }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "auth-middleware" "context" $) }}
+  namespace: {{ .Values.namespace }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/auth-mw-node-reader.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/auth-mw-node-reader.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: auth-middleware
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "auth-mw-node-reader" "context" $) }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/auth-mw-secrets-reader-binding.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/auth-mw-secrets-reader-binding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: auth-middleware
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "auth-mw-secrets-reader-binding" "context" $) }}
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "auth-mw-secrets-reader" "context" $) }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "auth-middleware" "context" $) }}
+  namespace: {{ .Values.namespace }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/auth-mw-secrets-reader.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/auth-mw-secrets-reader.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: auth-middleware
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "auth-mw-secrets-reader" "context" $) }}
+  namespace: {{ .Values.namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "extensionapi-jwt-secret" "context" $) }}
+  resources:
+  - secrets
+  verbs:
+  - get

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/auth-reader-kube-system.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/auth-reader-kube-system.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    internal.operator/target-namespace: kube-system
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "auth-reader" "context" $) }}
+  namespace: {{ index .Values.rbac.roleNamespaces "auth-reader" | default "kube-system" }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ include "hyperpod-ray-endpoint-operator.serviceAccountName" . }}
+  namespace: {{ .Values.namespace }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/connection-creator-binding.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/connection-creator-binding.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.namespaced }}
+kind: RoleBinding
+{{- else }}
+kind: ClusterRoleBinding
+{{- end }}
+metadata:
+{{- if .Values.rbac.namespaced }}
+  namespace: {{ .Values.namespace }}
+{{- end }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "connection-creator-binding" "context" $) }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.rbac.namespaced }}
+  kind: Role
+  {{- else }}
+  kind: ClusterRole
+  {{- end }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "connection-creator" "context" $) }}
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/connection-creator.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/connection-creator.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.namespaced }}
+kind: Role
+{{- else }}
+kind: ClusterRole
+{{- end }}
+metadata:
+{{- if .Values.rbac.namespaced }}
+  namespace: {{ .Values.namespace }}
+{{- end }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "connection-creator" "context" $) }}
+rules:
+- apiGroups:
+  - connection.access.sagemaker.amazonaws.com
+  resources:
+  - raydashboardconnections
+  verbs:
+  - create

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/jwt-rotator.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/jwt-rotator.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: jwt-rotator
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "jwt-rotator" "context" $) }}
+  namespace: {{ .Values.namespace }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "update"]
+  resourceNames: ["{{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "extensionapi-jwt-secret" "context" $) }}"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: jwt-rotator
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "jwt-rotator" "context" $) }}
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "jwt-rotator" "context" $) }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "jwt-rotator" "context" $) }}
+  namespace: {{ .Values.namespace }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/jwt-secrets-reader-binding.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/jwt-secrets-reader-binding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    component: security
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "jwt-secrets-reader-binding" "context" $) }}
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "jwt-secrets-reader" "context" $) }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "hyperpod-ray-endpoint-operator.serviceAccountName" . }}
+  namespace: {{ .Values.namespace }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/jwt-secrets-reader.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/jwt-secrets-reader.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    component: security
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "jwt-secrets-reader" "context" $) }}
+  namespace: {{ .Values.namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "extensionapi-jwt-secret" "context" $) }}
+  resources:
+  - secrets
+  verbs:
+  - get

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/leader-election-role.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/leader-election-role.yaml
@@ -1,0 +1,42 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "leader-election-role" "context" $) }}
+  namespace: {{ .Values.namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/leader-election-rolebinding.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/leader-election-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "leader-election-rolebinding" "context" $) }}
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "leader-election-role" "context" $) }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "hyperpod-ray-endpoint-operator.serviceAccountName" . }}
+  namespace: {{ .Values.namespace }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/manager-role.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/manager-role.yaml
@@ -1,0 +1,110 @@
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.namespaced }}
+kind: Role
+{{- else }}
+kind: ClusterRole
+{{- end }}
+metadata:
+{{- if .Values.rbac.namespaced }}
+  namespace: {{ .Values.namespace }}
+{{- end }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "manager-role" "context" $) }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - raycronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - access.sagemaker.amazonaws.com
+  resources:
+  - hyperpodrayendpointaccessstrategies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - traefik.io
+  resources:
+  - ingressroutes
+  - middlewares
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/manager-rolebinding.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/manager-rolebinding.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.namespaced }}
+kind: RoleBinding
+{{- else }}
+kind: ClusterRoleBinding
+{{- end }}
+metadata:
+{{- if .Values.rbac.namespaced }}
+  namespace: {{ .Values.namespace }}
+{{- end }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "manager-rolebinding" "context" $) }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.rbac.namespaced }}
+  kind: Role
+  {{- else }}
+  kind: ClusterRole
+  {{- end }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "manager-role" "context" $) }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "hyperpod-ray-endpoint-operator.serviceAccountName" . }}
+  namespace: {{ .Values.namespace }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/metrics-auth-role.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/metrics-auth-role.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.metrics.enable .Values.metrics.secure }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "metrics-auth-role" "context" $) }}
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+{{- end }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/metrics-auth-rolebinding.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/metrics-auth-rolebinding.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.metrics.enable .Values.metrics.secure }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "metrics-auth-rolebinding" "context" $) }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "metrics-auth-role" "context" $) }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "hyperpod-ray-endpoint-operator.serviceAccountName" . }}
+  namespace: {{ .Values.namespace }}
+{{- end }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/metrics-reader.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/metrics-reader.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.metrics.enable .Values.metrics.secure }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "metrics-reader" "context" $) }}
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+{{- end }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/serviceaccounts.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/rbac/serviceaccounts.yaml
@@ -1,0 +1,48 @@
+{{- if or (not (hasKey .Values.serviceAccount "enable")) .Values.serviceAccount.enable }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "controller-manager" "context" $) }}
+  namespace: {{ .Values.namespace }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: auth-middleware
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "auth-middleware" "context" $) }}
+  namespace: {{ .Values.namespace }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: jwt-rotator
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "jwt-rotator" "context" $) }}
+  namespace: {{ .Values.namespace }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/webhook/mutating-webhook-configuration.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/webhook/mutating-webhook-configuration.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.webhook.enable }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    {{- if .Values.certManager.enable }}
+    cert-manager.io/inject-ca-from: {{ .Values.namespace }}/{{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "serving-cert" "context" $) }}
+    {{- end }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "mutating-webhook-configuration" "context" $) }}
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
+      namespace: {{ .Values.namespace }}
+      path: /mutate-ray-io-v1-raycluster
+  failurePolicy: Ignore
+  name: mraycluster-v1.kb.io
+  rules:
+  - apiGroups:
+    - ray.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - rayclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
+      namespace: {{ .Values.namespace }}
+      path: /mutate-ray-io-v1-rayjob
+  failurePolicy: Ignore
+  name: mrayjob-v1.kb.io
+  rules:
+  - apiGroups:
+    - ray.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - rayjobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
+      namespace: {{ .Values.namespace }}
+      path: /mutate-ray-io-v1-rayservice
+  failurePolicy: Ignore
+  name: mrayservice-v1.kb.io
+  rules:
+  - apiGroups:
+    - ray.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - rayservices
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
+      namespace: {{ .Values.namespace }}
+      path: /mutate-ray-io-v1-raycronjob
+  failurePolicy: Ignore
+  name: mraycronjob-v1.kb.io
+  rules:
+  - apiGroups:
+    - ray.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - raycronjobs
+  sideEffects: None
+{{- end }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/webhook/validating-webhook-configuration.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/webhook/validating-webhook-configuration.yaml
@@ -1,0 +1,91 @@
+{{- if .Values.webhook.enable }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    {{- if .Values.certManager.enable }}
+    cert-manager.io/inject-ca-from: {{ .Values.namespace }}/{{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "serving-cert" "context" $) }}
+    {{- end }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "validating-webhook-configuration" "context" $) }}
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
+      namespace: {{ .Values.namespace }}
+      path: /validate-ray-io-v1-raycluster
+  failurePolicy: Fail
+  name: vraycluster-v1.kb.io
+  rules:
+  - apiGroups:
+    - ray.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rayclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
+      namespace: {{ .Values.namespace }}
+      path: /validate-ray-io-v1-rayjob
+  failurePolicy: Fail
+  name: vrayjob-v1.kb.io
+  rules:
+  - apiGroups:
+    - ray.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rayjobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
+      namespace: {{ .Values.namespace }}
+      path: /validate-ray-io-v1-rayservice
+  failurePolicy: Fail
+  name: vrayservice-v1.kb.io
+  rules:
+  - apiGroups:
+    - ray.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rayservices
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
+      namespace: {{ .Values.namespace }}
+      path: /validate-ray-io-v1-raycronjob
+  failurePolicy: Fail
+  name: vraycronjob-v1.kb.io
+  rules:
+  - apiGroups:
+    - ray.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - raycronjobs
+  sideEffects: None
+{{- end }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/webhook/webhook-service.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/webhook/webhook-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.webhook.enable }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "hyperpod-ray-endpoint-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
+  namespace: {{ .Values.namespace }}
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: {{ .Values.webhook.port }}
+  selector:
+    app.kubernetes.io/name: {{ include "hyperpod-ray-endpoint-operator.name" . }}
+    control-plane: controller-manager
+{{- end }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/values.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/values.yaml
@@ -1,0 +1,323 @@
+## Namespace for all resources deployed by this chart.
+##
+namespace: "hyperpod-ray"
+
+## String to partially override chart.fullname template (will maintain the release name)
+##
+# nameOverride: ""
+
+## String to fully override chart.fullname template
+##
+# fullnameOverride: ""
+
+## AWS region for resolving regional ECR image registries.
+## Required when image.override is not explicitly set.
+##
+## Region detection priority:
+## 1. This explicit region setting (highest priority)
+## 2. Global region setting (global.region from parent chart)
+##
+## Supported regions: ca-central-1, us-east-1, us-east-2, us-west-1, us-west-2,
+## eu-west-1, eu-west-2, eu-central-1, eu-north-1, eu-south-2, ap-northeast-1,
+## ap-northeast-2, ap-south-1, ap-south-2, ap-southeast-1, ap-southeast-2,
+## ap-southeast-3, ap-southeast-4, sa-east-1
+region: ""
+
+## Container image configuration
+##
+image:
+  ## Image tag override.
+  ## If not specified, defaults to 1.0.173.0_1.0.18.0.
+  ##
+  # tag: ""
+
+  ## Override the full image URI.
+  ## If specified, this overrides the automatic region-based URI selection.
+  ## Example: "622623004016.dkr.ecr.us-east-1.amazonaws.com/hyperpod-ray-endpoint-operator:0.1.0"
+  ##
+  override: ""
+
+## KMS configuration for JWT signing
+## When set, both the manager and auth-middleware use AWS KMS HMAC instead of K8s secrets.
+##
+kmsKeyArn: ""
+
+## Domain for Ray dashboard URLs (e.g., spaces.example.com)
+## Required for the extension API and controller to function.
+##
+domain: ""
+
+## Admin group for webhook annotation protection bypass
+##
+adminGroup: "system:masters"
+
+## Configure the controller manager deployment
+##
+manager:
+  ## Set to false to skip manager installation
+  ##
+  enabled: true
+
+  replicas: 1
+
+  ## Enable endpoints by default for all RayClusters (required: "true" or "false")
+  ##
+  enableEndpointsByDefault: ""
+
+  image:
+    pullPolicy: IfNotPresent
+
+  ## Arguments
+  ##
+  args:
+    - --leader-elect
+    - --log-file-path=/var/log/aws/clusters/ray-endpoint-operator/hyperpod-ray-endpoint-operator.log
+    - --enable-extension-api
+
+  ## Environment variables
+  ##
+  env:
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+
+  ## Env overrides (--set manager.envOverrides.VAR=value)
+  ## Same name in env above: this value takes precedence.
+  ##
+  envOverrides: {}
+
+  ## Image pull secrets
+  ##
+  # imagePullSecrets:
+  #   - name: myregistrykey
+
+  ## Pod-level security settings
+  ##
+  podSecurityContext:
+    fsGroup: 65532
+    runAsGroup: 65532
+    runAsNonRoot: true
+    runAsUser: 65532
+    seccompProfile:
+      type: RuntimeDefault
+
+  ## Container-level security settings
+  ##
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+
+  ## Resource limits and requests
+  ##
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+
+  ## Manager pod's affinity
+  ##
+  affinity: {}
+
+  ## Manager pod's node selector
+  ##
+  nodeSelector:
+    kubernetes.io/arch: amd64
+    sagemaker.amazonaws.com/compute-type: hyperpod
+
+  ## Manager pod's tolerations
+  ##
+  tolerations: []
+
+  ## Deployment strategy
+  ##
+  # strategy:
+  #   type: RollingUpdate
+  #   rollingUpdate:
+  #     maxSurge: 25%
+  #     maxUnavailable: 25%
+
+  ## Priority class name
+  ##
+  # priorityClassName: ""
+
+  ## Topology spread constraints
+  ##
+  # topologySpreadConstraints: []
+
+  ## Termination grace period seconds
+  ##
+  terminationGracePeriodSeconds: 10
+
+  ## Custom Deployment labels
+  ##
+  # labels: {}
+
+  ## Custom Deployment annotations
+  ##
+  # annotations: {}
+
+  ## Custom Pod labels and annotations
+  ##
+  # pod:
+  #   labels: {}
+  #   annotations: {}
+
+  ## Extra volumes and volume mounts
+  ##
+  extraVolumes: []
+
+  extraVolumeMounts: []
+
+## RBAC configuration
+##
+rbac:
+  ## RBAC resource scope
+  ## - false (default): ClusterRole/ClusterRoleBinding (all namespaces)
+  ## - true: Role/RoleBinding (release namespace only)
+  ##
+  namespaced: false
+
+  ## Multi-namespace RBAC role mappings (advanced use)
+  ## Maps role suffixes to target namespaces for multi-namespace deployments
+  ##
+  roleNamespaces:
+    "auth-reader": "kube-system"
+
+  ## Helper roles for CRD management (admin/editor/viewer)
+  ##
+  helpers:
+    ## Install convenience admin/editor/viewer roles for CRDs
+    ##
+    enable: false
+
+## ServiceAccount configuration
+##
+serviceAccount:
+  # Install default ServiceAccount provided
+  enable: true
+
+  ## Existing ServiceAccount name (only when enable=false)
+  ## Note: When enable=true, respects nameOverride/fullnameOverride
+  ##
+  # name: ""
+
+  ## Custom ServiceAccount annotations
+  ##
+  # annotations: {}
+
+  ## Custom ServiceAccount labels
+  ##
+  # labels: {}
+
+## Custom Resource Definitions
+##
+crd:
+  # Install CRDs with the chart
+  enable: true
+  # Keep CRDs when uninstalling
+  keep: true
+
+## Controller metrics endpoint.
+## Enable to expose /metrics endpoint
+##
+metrics:
+  enable: true
+  # Metrics server port
+  port: 8443
+  # Enable secure metrics: HTTPS with certs/auth (true) or HTTP (false).
+  # Note: Metrics authn/authz needs ClusterRole access.
+  secure: true
+
+## Cert-manager integration for TLS certificates.
+## Required for webhook certificates and metrics endpoint certificates.
+##
+certManager:
+  enable: true
+
+## Webhook server configuration
+##
+webhook:
+  enable: true
+  # Webhook server port
+  port: 9443
+
+## Prometheus ServiceMonitor for metrics scraping.
+## Requires prometheus-operator to be installed in the cluster.
+##
+prometheus:
+  enable: false
+
+## Auth-middleware deployment configuration
+##
+authMiddleware:
+  ## Set to false to skip auth-middleware installation
+  ##
+  enabled: true
+
+  replicas: 2
+
+  image:
+    pullPolicy: IfNotPresent
+
+  ## Environment variables
+  ##
+  env:
+    port: "8080"
+    jwtIssuer: "hyperpod-ray-endpoint-operator"
+    jwtAudience: "hyperpod-ray-endpoint-operator"
+    sessionTTL: "6h"
+    cookieName: "ray_session"
+    cookieSecure: "true"
+    cookieSameSite: "lax"
+    logFilePath: "/var/log/aws/clusters/ray-endpoint-operator/hyperpod-ray-endpoint-operator-auth-middleware.log"
+
+  ## Resource limits and requests
+  ##
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  ## Pod-level security settings
+  ##
+  podSecurityContext:
+    fsGroup: 65532
+    runAsGroup: 65532
+    runAsNonRoot: true
+    runAsUser: 65532
+    seccompProfile:
+      type: RuntimeDefault
+
+  ## Container-level security settings
+  ##
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+
+  ## Node selector
+  ##
+  nodeSelector:
+    kubernetes.io/arch: amd64
+    sagemaker.amazonaws.com/compute-type: hyperpod
+
+  ## Tolerations
+  ##
+  tolerations: []
+
+  ## Termination grace period seconds
+  ##
+  terminationGracePeriodSeconds: 30
+

--- a/helm_chart/HyperPodHelmChart/values.yaml
+++ b/helm_chart/HyperPodHelmChart/values.yaml
@@ -282,3 +282,21 @@ hyperpod-patching:
   enabled: true
 gpu-operator:
   enabled: false
+
+hyperpod-ray-endpoint-operator:
+  enabled: false
+  # Namespace for the ray endpoint operator resources (default: hyperpod-ray)
+  namespace: "hyperpod-ray"
+  # AWS region for resolving regional ECR image registries
+  region: ""
+  # Container image configuration
+  image:
+    # Image tag override (defaults to Chart.appVersion)
+    # tag: ""
+    # Override the full image URI (skips region-based resolution)
+    # Example: "622623004016.dkr.ecr.us-east-1.amazonaws.com/hyperpod-ray-endpoint-operator:0.1.0"
+    override: ""
+  # KMS key ARN for JWT signing (optional)
+  kmsKeyArn: ""
+  # Domain for Ray dashboard URLs
+  domain: ""


### PR DESCRIPTION
## Summary

Adds the hyperpod-ray-endpoint-operator as a sub-chart to the HyperPodHelmChart. The chart can be installed with the following command - 

```
helm install hyperpod-ray-endpoint-operator \
  ./helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator \
  --create-namespace \
  --set region=us-west-2 \
  --set domain=<domain> \
```

To install the chart in a specific namespace - 
```
helm install hyperpod-ray-endpoint-operator \
  ./helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator \
  --namespace my-custom-ns --create-namespace \
  --set region=us-west-2 \
  --set namespace=my-custom-ns \
  --set domain=<domain>
```

To install with KMS-based JWT signing (instead of K8s Secrets):

```bash
helm install hyperpod-ray-endpoint-operator \
  ./helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator \
  --create-namespace \
  --set region=us-west-2 \
  --set domain=<domain> \
  --set kmsKeyArn="arn:aws:kms:us-west-2:123456789012:key/your-key-id"
```

To install with a custom admin group:

```bash
helm install hyperpod-ray-endpoint-operator \
  ./helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator \
  --create-namespace \
  --set region=us-west-2 \
  --set domain=<domain> \
  --set adminGroup=my-admin-group
```

To install with a custom image override (e.g., for testing with a specific digest):

```bash
helm install hyperpod-ray-endpoint-operator \
  ./helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator \
  --create-namespace \
  --set region=us-west-2 \
  --set domain=<domain> \
  --set image.override=123456789012.dkr.ecr.us-west-2.amazonaws.com/hyperpod-ray-endpoint-operator@sha256:<digest>
```

To install from the parent chart:

```bash
helm install hyperpod ./helm_chart/HyperPodHelmChart \
  --namespace aws-hyperpod --create-namespace \
  --set hyperpod-ray-endpoint-operator.enabled=true \
  --set hyperpod-ray-endpoint-operator.region=us-west-2 \
  --set hyperpod-ray-endpoint-operator.domain=<domain>
```


## HyperPod Ray Endpoint Operator — Installation Defaults

### Required at install time

| Parameter | Description |
|-----------|-------------|
| `region` | AWS region (required unless `image.override` is set) |
| `domain` | Domain for Ray dashboard URLs (e.g., `spaces.example.com`) |

### Namespace

| Setting | Default |
|---------|---------|
| `namespace` | `hyperpod-ray` |

### Image

| Setting | Default |
|---------|---------|
| Image name | `hyperpod-ray-endpoint-operator` (hardcoded) |
| Image tag | `1.0.173.0_1.0.18.0` |
| Registry | Resolved from region → ECR account map (19 regions) |
| `image.override` | `""` (off) — when set, bypasses all resolution |

### JWT signing

| Setting | Default | Behavior |
|---------|---------|----------|
| `kmsKeyArn` | `""` (empty) | K8s Secret — when set, switches to AWS KMS HMAC |

### Controller Manager

| Setting | Default |
|---------|---------|
| `manager.enabled` | `true` |
| `manager.replicas` | `1` |
| `manager.image.pullPolicy` | `IfNotPresent` |
| `manager.resources.limits` | 500m CPU, 128Mi memory |
| `manager.resources.requests` | 10m CPU, 64Mi memory |
| `manager.nodeSelector` | `amd64`, `sagemaker.amazonaws.com/compute-type: hyperpod` |
| `manager.terminationGracePeriodSeconds` | `10` |
| Leader election | On (`--leader-elect`) |
| Extension API | On (`--enable-extension-api`) |

### Auth Middleware

| Setting | Default |
|---------|---------|
| `authMiddleware.enabled` | `true` |
| `authMiddleware.replicas` | `2` |
| `authMiddleware.image.pullPolicy` | `IfNotPresent` |
| `authMiddleware.resources.limits` | 200m CPU, 256Mi memory |
| `authMiddleware.resources.requests` | 100m CPU, 128Mi memory |
| `authMiddleware.env.sessionTTL` | `6h` |
| `authMiddleware.env.cookieSecure` | `true` |
| `authMiddleware.env.cookieSameSite` | `lax` |
| `authMiddleware.nodeSelector` | `amd64`, `sagemaker.amazonaws.com/compute-type: hyperpod` |
| `authMiddleware.terminationGracePeriodSeconds` | `30` |

### Access Control

| Setting | Default |
|---------|---------|
| `adminGroup` | `system:masters` |

### Metrics & Monitoring

| Setting | Default |
|---------|---------|
| `metrics.enable` | `true` |
| `metrics.port` | `8443` |
| `metrics.secure` | `true` (HTTPS) |
| `prometheus.enable` | `false` (no ServiceMonitor) |

### Security (all components)

- `runAsNonRoot: true`, UID/GID `65532`
- `readOnlyRootFilesystem: true`
- `allowPrivilegeEscalation: false`
- All capabilities dropped
- Seccomp: `RuntimeDefault`

### Parent chart

| Setting | Default |
|---------|---------|
| `hyperpod-ray-endpoint-operator.enabled` | `false` (must explicitly enable) |



## Testing

Verified with `helm template` across multiple regions and override scenarios. Deployed to local cluster against different namespace and ran internal e2e tests to validate functionality. 