### PR TITLE
feat: add g7 instances to nvidia-device-plugin and aws-efa-k8s-device-plugin

### DIFF
--- a/helm_chart/HyperPodHelmChart/values.yaml
+++ b/helm_chart/HyperPodHelmChart/values.yaml
@@ -188,6 +188,12 @@ nvidia-device-plugin:
               - ml.g7e.12xlarge
               - ml.g7e.24xlarge
               - ml.g7e.48xlarge
+              - ml.g7.2xlarge
+              - ml.g7.4xlarge
+              - ml.g7.8xlarge
+              - ml.g7.12xlarge
+              - ml.g7.24xlarge
+              - ml.g7.48xlarge
               - ml.gr6.4xlarge
               - ml.gr6.8xlarge
               - ml.p4d.24xlarge
@@ -239,6 +245,10 @@ aws-efa-k8s-device-plugin:
       - ml.g7e.12xlarge
       - ml.g7e.24xlarge
       - ml.g7e.48xlarge
+      - ml.g7.8xlarge
+      - ml.g7.12xlarge
+      - ml.g7.24xlarge
+      - ml.g7.48xlarge
       - ml.gr6.8xlarge
       - ml.i3en.12xlarge
       - ml.i3en.24xlarge


### PR DESCRIPTION
…-plugin

## What's changing and why?
add g7 instances to nvidia-device-plugin and aws-efa-k8s-device-plugin


## Before/After UX
<!-- Show the user experience before and after your changes -->
**Before:**
nvidia-device-plugin and aws-efa-k8s-device-plugin and pods would not run

**After:**
```
kubectl get pods -A
NAMESPACE      NAME                                               READY   STATUS             RESTARTS        AGE
aws-hyperpod   health-monitoring-agent-9x48t                      1/1     Running            0               104s
aws-hyperpod   health-monitoring-agent-c7l7h                      1/1     Running            0               104s
kube-system    aws-node-7z9bp                                     2/2     Running            0               26m
kube-system    aws-node-rc6s6                                     2/2     Running            0               26m
kube-system    coredns-764cd7bc88-2ckdb                           0/1     Running            0               100m
kube-system    coredns-764cd7bc88-nq29f                           0/1     Running            0               100m
kube-system    dependencies-aws-efa-k8s-device-plugin-8zgjf       1/1     Running            0               105s
kube-system    dependencies-aws-efa-k8s-device-plugin-j2np6       1/1     Running            0               105s
kube-system    dependencies-mpi-operator-5d4c7b8d44-6bc7w         1/1     Running            0               95m
kube-system    dependencies-nvidia-device-plugin-665m8            1/1     Running            0               104s
kube-system    dependencies-nvidia-device-plugin-flcnf            1/1     Running            0               104s
kube-system    kube-proxy-6vcxh                                   1/1     Running            0               26m
kube-system    kube-proxy-lrzfw                                   1/1     Running            0               26m
kube-system    metrics-server-656c94fffb-c4ms5                    0/1     CrashLoopBackOff   11 (5m ago)     98m
kube-system    metrics-server-656c94fffb-c997z                    0/1     CrashLoopBackOff   13 (16s ago)    98m
kubeflow       dependencies-training-operators-8465664bdf-j4w9j   0/1     CrashLoopBackOff   6 (3m11s ago)   95m
```

## How was this change tested?
scaled up HyperPod cluster and applied helm chart with g7 values


## Are unit tests added?


## Are integration tests added?


## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [ ] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only