### PR TITLE
Add system-node-critical priorityClass to health-monitoring-agent DaemonSets

### DIFF
--- a/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/templates/health-monitoring-agent.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/templates/health-monitoring-agent.yaml
@@ -159,6 +159,7 @@ spec:
             - name: localtime
               mountPath: /etc/localtime
               readOnly: true
+      priorityClassName: {{ .Values.priorityClassName | default "system-node-critical" }}
       serviceAccountName: health-monitoring-agent
       volumes:
         - name: log
@@ -250,6 +251,7 @@ spec:
             - name: localtime
               mountPath: /etc/localtime
               readOnly: true
+      priorityClassName: {{ .Values.priorityClassName | default "system-node-critical" }}
       serviceAccountName: health-monitoring-agent
       volumes:
         - name: log

--- a/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/values.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/health-monitoring-agent/values.yaml
@@ -30,3 +30,8 @@ hmaimage: ""
 
 # Enable debug output for region selection process
 debug: true
+
+# PriorityClass for the HMA DaemonSet pods.
+# system-node-critical ensures HMA is the last pod evicted under node pressure
+# (e.g. DiskPressure), preventing loss of health monitoring. See P438078245.
+priorityClassName: system-node-critical


### PR DESCRIPTION
## What's changing and why?

Adds a `priorityClassName` (defaulting to the Kubernetes built-in `system-node-critical`) to both health-monitoring-agent DaemonSets:

- `health-monitoring-agent` (NVIDIA / GPU)
- `health-monitoring-agent-non-nvidia` (Trainium / Inferentia)

The value is configurable via `.Values.priorityClassName` and falls back to `system-node-critical` when unset.

**Why:** Under node `DiskPressure`, HMA was evicted moments before a GPU failure occurred — so the failure went undetected and unremediated. `system-node-critical` (priority value `2000001000`) makes HMA among the last pods evicted under node pressure, after training and other monitoring pods, preserving health monitoring exactly when it matters most. This mirrors what EKSNodeMonitoringAgent already does. Because `system-node-critical` is a built-in PriorityClass, no additional PriorityClass object needs to be created.


## Before / After UX

- **Before:** HMA pods run at priority `0`. Under node pressure (e.g. `DiskPressure`), they can be evicted early — potentially before or during a hardware failure — leaving the node unmonitored.
- **After:** HMA pods run at priority `2000001000` (`system-node-critical`) by default, so the kubelet evicts them last, keeping health monitoring alive during node pressure. Operators can override or disable via `.Values.priorityClassName`.

## How was this change tested?

Validated through render, lint, dry-run, and a live apply/observe/revert on a real cluster:

1. **`helm template`** — rendered both DaemonSets and confirmed `priorityClassName: system-node-critical` appears in each pod spec; verified `--set priorityClassName=<x>` propagates correctly, with fallback to `system-node-critical` when unset.
2. **`helm lint`** — passes clean.
3. **Server-side dry-run** — `kubectl apply --server-side --dry-run` accepted with no schema/admission errors.
4. **Live apply → observe → revert** on an e2e test cluster (~10 nodes, 4 HMA pods): after apply, all HMA pods rolled out cleanly and reported `priority: 2000001000` (up from `0`); reverting returned them to `priority: 0` with no priorityClassName, again via a clean rollout. No DaemonSet disruption during either transition.

## Are unit tests added?

No — this is a Helm chart template/values change with no application code. Coverage is provided by the `helm template` / `helm lint` render checks above.

## Are integration tests added?

No new automated integration tests. Verified manually via the live apply/observe/revert described above.


## Reviewer Guidelines

‼️ **Merge Requirements**: PRs with failing integration tests cannot be merged without justification. 

One of the following must be true:
- [ ] All automated PR checks pass
- [ ] Failed tests include local run results/screenshots proving they work
- [ ] Changes are documentation-only