### PR TITLE
Fix hyp create ray-dashboard-connection command to load credentials through load_kubeconfig

### DIFF
--- a/src/sagemaker/hyperpod/cli/commands/ray_dashboard_connection.py
+++ b/src/sagemaker/hyperpod/cli/commands/ray_dashboard_connection.py
@@ -27,36 +27,15 @@ from sagemaker.hyperpod.common.telemetry.constants import Feature
 from sagemaker.hyperpod.common.cli_decorators import handle_cli_exceptions
 
 
-def _get_eks_api_client():
-    """Load kubeconfig and create an authenticated API client.
+def _load_kube_config():
+    """Load kubeconfig so the default ApiClient is authenticated.
 
-    Works around a kubernetes-client issue where exec-based tokens
-    are not properly forwarded in the Authorization header.
+    Uses the library's default client (as HPSpace does) rather than copying
+    the token out of Configuration.api_key. The api_key entry is named
+    differently across kubernetes-client releases ("authorization" in 36.0.0,
+    "BearerToken" in 36.0.3+), so reading it by name is version-fragile.
     """
     config.load_kube_config()
-    configuration = client.Configuration.get_default_copy()
-
-    # Extract the token from the exec provider
-    token = None
-    if configuration.api_key and "authorization" in configuration.api_key:
-        token_value = configuration.api_key["authorization"]
-        prefix = "Bearer "
-        if token_value.startswith(prefix):
-            token = token_value.removeprefix(prefix)
-        else:
-            token = token_value
-
-    # Clear api_key to avoid double-auth conflicts
-    configuration.api_key = {}
-    configuration.api_key_prefix = {}
-
-    if token:
-        return client.ApiClient(
-            configuration,
-            header_name="Authorization",
-            header_value=f"Bearer {token}",
-        )
-    return client.ApiClient(configuration)
 
 
 @click.command("ray-dashboard-connection")
@@ -66,7 +45,7 @@ def _get_eks_api_client():
 @handle_cli_exceptions()
 def create_ray_dashboard_connection(cluster_name, namespace):
     """Create a RayDashboardConnection to get a dashboard URL for a RayCluster."""
-    api_client = _get_eks_api_client()
+    _load_kube_config()
 
     body = {
         "apiVersion": f"{RAY_DASHBOARD_CONNECTION_GROUP}/{RAY_DASHBOARD_CONNECTION_VERSION}",
@@ -79,7 +58,7 @@ def create_ray_dashboard_connection(cluster_name, namespace):
         },
     }
 
-    api = client.CustomObjectsApi(api_client)
+    api = client.CustomObjectsApi()
 
     try:
         result = api.create_namespaced_custom_object(

--- a/test/unit_tests/cli/test_ray_dashboard_connection.py
+++ b/test/unit_tests/cli/test_ray_dashboard_connection.py
@@ -13,9 +13,9 @@ class TestRayDashboardConnectionCommand:
     def setup_method(self):
         self.runner = CliRunner()
 
-    @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection._get_eks_api_client')
+    @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection._load_kube_config')
     @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection.client.CustomObjectsApi')
-    def test_create_success_returns_url(self, mock_custom_objects_api_class, mock_get_client):
+    def test_create_success_returns_url(self, mock_custom_objects_api_class, mock_load_config):
         """Test successful creation returns the connection URL"""
         mock_api = Mock()
         mock_api.create_namespaced_custom_object.return_value = {
@@ -24,7 +24,6 @@ class TestRayDashboardConnectionCommand:
             }
         }
         mock_custom_objects_api_class.return_value = mock_api
-        mock_get_client.return_value = Mock()
 
         result = self.runner.invoke(create_ray_dashboard_connection, [
             '--cluster-name', 'my-raycluster',
@@ -46,16 +45,15 @@ class TestRayDashboardConnectionCommand:
             },
         )
 
-    @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection._get_eks_api_client')
+    @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection._load_kube_config')
     @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection.client.CustomObjectsApi')
-    def test_create_default_namespace(self, mock_custom_objects_api_class, mock_get_client):
+    def test_create_default_namespace(self, mock_custom_objects_api_class, mock_load_config):
         """Test namespace defaults to 'default' when not specified"""
         mock_api = Mock()
         mock_api.create_namespaced_custom_object.return_value = {
             "status": {"connectionUrl": "https://example.com/dashboard"}
         }
         mock_custom_objects_api_class.return_value = mock_api
-        mock_get_client.return_value = Mock()
 
         result = self.runner.invoke(create_ray_dashboard_connection, [
             '--cluster-name', 'my-raycluster',
@@ -66,16 +64,15 @@ class TestRayDashboardConnectionCommand:
         call_kwargs = mock_api.create_namespaced_custom_object.call_args[1]
         assert call_kwargs["namespace"] == "default"
 
-    @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection._get_eks_api_client')
+    @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection._load_kube_config')
     @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection.client.CustomObjectsApi')
-    def test_create_empty_url_raises_error(self, mock_custom_objects_api_class, mock_get_client):
+    def test_create_empty_url_raises_error(self, mock_custom_objects_api_class, mock_load_config):
         """Test that empty connectionUrl raises an error"""
         mock_api = Mock()
         mock_api.create_namespaced_custom_object.return_value = {
             "status": {"connectionUrl": ""}
         }
         mock_custom_objects_api_class.return_value = mock_api
-        mock_get_client.return_value = Mock()
 
         result = self.runner.invoke(create_ray_dashboard_connection, [
             '--cluster-name', 'my-raycluster',
@@ -86,16 +83,15 @@ class TestRayDashboardConnectionCommand:
         assert "Failed to get dashboard URL" in result.output
         assert "contact your cluster administrator" in result.output
 
-    @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection._get_eks_api_client')
+    @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection._load_kube_config')
     @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection.client.CustomObjectsApi')
-    def test_create_no_status_raises_error(self, mock_custom_objects_api_class, mock_get_client):
+    def test_create_no_status_raises_error(self, mock_custom_objects_api_class, mock_load_config):
         """Test that missing status raises an error"""
         mock_api = Mock()
         mock_api.create_namespaced_custom_object.return_value = {
             "metadata": {"name": "generated-name"}
         }
         mock_custom_objects_api_class.return_value = mock_api
-        mock_get_client.return_value = Mock()
 
         result = self.runner.invoke(create_ray_dashboard_connection, [
             '--cluster-name', 'my-raycluster',
@@ -104,9 +100,9 @@ class TestRayDashboardConnectionCommand:
         assert result.exit_code != 0
         assert "Failed to get dashboard URL" in result.output
 
-    @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection._get_eks_api_client')
+    @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection._load_kube_config')
     @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection.client.CustomObjectsApi')
-    def test_create_404_api_not_installed(self, mock_custom_objects_api_class, mock_get_client):
+    def test_create_404_api_not_installed(self, mock_custom_objects_api_class, mock_load_config):
         """Test 404 when operator is not installed shows install instructions"""
         mock_api = Mock()
         mock_api.create_namespaced_custom_object.side_effect = ApiException(
@@ -123,7 +119,6 @@ class TestRayDashboardConnectionCommand:
             '"details":{"group":"connection.access.sagemaker.amazonaws.com","kind":"raydashboardconnections"}}'
         )
         mock_custom_objects_api_class.return_value = mock_api
-        mock_get_client.return_value = Mock()
 
         result = self.runner.invoke(create_ray_dashboard_connection, [
             '--cluster-name', 'my-raycluster',
@@ -135,9 +130,9 @@ class TestRayDashboardConnectionCommand:
         assert "hyperpod-ray-endpoint-operator" in result.output
 
     @patch('sagemaker.hyperpod.common.cli_decorators._namespace_exists', return_value=True)
-    @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection._get_eks_api_client')
+    @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection._load_kube_config')
     @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection.client.CustomObjectsApi')
-    def test_create_404_namespace_not_found(self, mock_custom_objects_api_class, mock_get_client, mock_ns_exists):
+    def test_create_404_namespace_not_found(self, mock_custom_objects_api_class, mock_load_config, mock_ns_exists):
         """Test 404 for missing namespace shows raw error"""
         mock_api = Mock()
         mock_api.create_namespaced_custom_object.side_effect = ApiException(
@@ -147,7 +142,6 @@ class TestRayDashboardConnectionCommand:
         )
         mock_api.create_namespaced_custom_object.side_effect.body = '{"message":"namespaces not-exists not found"}'
         mock_custom_objects_api_class.return_value = mock_api
-        mock_get_client.return_value = Mock()
 
         result = self.runner.invoke(create_ray_dashboard_connection, [
             '--cluster-name', 'my-raycluster',
@@ -158,9 +152,9 @@ class TestRayDashboardConnectionCommand:
         assert "not found" in result.output.lower() or "not-exists" in result.output
 
     @patch('sagemaker.hyperpod.common.cli_decorators._namespace_exists', return_value=True)
-    @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection._get_eks_api_client')
+    @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection._load_kube_config')
     @patch('sagemaker.hyperpod.cli.commands.ray_dashboard_connection.client.CustomObjectsApi')
-    def test_create_403_raises_exception(self, mock_custom_objects_api_class, mock_get_client, mock_ns_exists):
+    def test_create_403_raises_exception(self, mock_custom_objects_api_class, mock_load_config, mock_ns_exists):
         """Test 403 forbidden is propagated as an error"""
         mock_api = Mock()
         exc = ApiException(
@@ -171,7 +165,6 @@ class TestRayDashboardConnectionCommand:
         exc.body = '{"message":"forbidden"}'
         mock_api.create_namespaced_custom_object.side_effect = exc
         mock_custom_objects_api_class.return_value = mock_api
-        mock_get_client.return_value = Mock()
 
         result = self.runner.invoke(create_ray_dashboard_connection, [
             '--cluster-name', 'my-raycluster',


### PR DESCRIPTION
<html><head></head><body>
<h2>Problem</h2>
<p><code>hyp create ray-dashboard-connection</code> sends the request unauthenticated on fresh install not using K8s version 36.0.0. The EKS API server sees <code>system:anonymous</code> and rejects it with 403 (or 401, depending on cluster auth config).</p>
<h2>Root cause</h2>
<p><code>_get_eks_api_client()</code> reads the bearer token by name from a detached config copy, then clears <code>api_key</code> unconditionally:</p>
<pre><code class="language-python">configuration = client.Configuration.get_default_copy()
if configuration.api_key and "authorization" in configuration.api_key:
    ...
configuration.api_key = {}
</code></pre>
<p><code>load_kube_config()</code> names that entry differently across kubernetes-client releases — <code>authorization</code> in 36.0.0, <code>BearerToken</code> in 36.0.3. On 36.0.3 the lookup misses, no <code>Authorization</code> header is attached, and the clear discards the token that <em>was</em> loaded. The client ends up with no credentials.</p>
<p><code>setup.py</code> declares <code>kubernetes&gt;=33.1.0,!=36.0.0</code>, excluding the only version the code works on, so every fresh resolve is broken.</p>

kubernetes | api_key key | Auth header | Result
-- | -- | -- | --
36.0.0 | authorization | attached | authenticates as caller's IAM identity
36.0.3 | BearerToken | not attached | system:anonymous → 403


<h2>Fix</h2>
<p>Delete <code>_get_eks_api_client()</code> and use the default client, as <code>HPSpace</code> already does for <code>space_access</code>:</p>
<pre><code class="language-python">config.load_kube_config()
...
api = client.CustomObjectsApi()      # was: CustomObjectsApi(api_client)
</code></pre>
<p>The default <code>ApiClient</code> reads the <code>Configuration</code> that <code>load_kube_config()</code> populated, so auth resolves via the library's own <code>auth_settings()</code> regardless of key name, and the exec-credential refresh hook is preserved.</p>
<h2>Testing</h2>
<p>Verified on 36.0.3 (the breaking version) and 36.0.0: the command authenticates as the caller's IAM role and returns a valid presigned URL whose JWT <code>sub</code> matches. Updated the 7 unit tests that patched the removed function; request-body assertions unchanged.</p>
</body></html>