### PR TITLE
feat(helm): inject OPERATOR_VERSION env into ray-endpoint-operator manager

### DIFF
--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/_helpers.tpl
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/_helpers.tpl
@@ -63,6 +63,15 @@ Otherwise, use the standard resourceName helper with "controller-manager" suffix
 {{- end }}
 
 {{/*
+Resolve the container image tag.
+Defaults to the pinned operator version when .Values.image.tag is not set.
+Reused by both imageUri and the manager's OPERATOR_VERSION env var.
+*/}}
+{{- define "hyperpod-ray-endpoint-operator.imageTag" -}}
+{{- .Values.image.tag | default "1.0.188.0_1.0.19.0" -}}
+{{- end }}
+
+{{/*
 Resolve the container image URI.
 Priority for region:
   1. .Values.region (explicit setting)
@@ -114,7 +123,7 @@ Priority for image URI:
   {{- fail (printf "Unsupported AWS region: %s. Set image.override explicitly for non-standard regions." $region) -}}
 {{- end -}}
 
-{{- $imageTag := .Values.image.tag | default "1.0.188.0_1.0.19.0" -}}
+{{- $imageTag := include "hyperpod-ray-endpoint-operator.imageTag" . -}}
 {{- printf "%s.dkr.ecr.%s.amazonaws.com/hyperpod-ray-endpoint-operator:%s" $accountId $region $imageTag -}}
 {{- end -}}
 {{- end }}

--- a/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/manager/manager.yaml
+++ b/helm_chart/HyperPodHelmChart/charts/hyperpod-ray-endpoint-operator/templates/manager/manager.yaml
@@ -106,6 +106,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: OPERATOR_VERSION
+            value: {{ include "hyperpod-ray-endpoint-operator.imageTag" . | quote }}
 {{- if or .Values.manager.env (and (kindIs "map" .Values.manager.envOverrides) (not (empty .Values.manager.envOverrides))) }}
           {{- if .Values.manager.env }}
           {{- toYaml .Values.manager.env | nindent 10 }}


### PR DESCRIPTION
Adds an imageTag helper and injects `OPERATOR_VERSION` into the Ray Endpoint Operator manager container env.

`{"level":"info","ts":"2026-09-10T17:08:54Z","logger":"setup","msg":"Operator version","version":"1.0.188.0_1.0.19.0"}`